### PR TITLE
fix: prevent settings from being reset on partial saves

### DIFF
--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -112,6 +112,9 @@ final class SettingsRepository: PSettingsRepository {
                     if let hideHeroImage = settings.hideHeroImage {
                         existingSettings.hideHeroImage = hideHeroImage
                     }
+                    if let hideSummary = settings.hideSummary {
+                        existingSettings.hideSummary = hideSummary
+                    }
                     if let customCSS = settings.customCSS {
                         existingSettings.customCSS = customCSS
                     }
@@ -195,6 +198,7 @@ final class SettingsRepository: PSettingsRepository {
                         hideProgressBar: settingEntity?.hideProgressBar,
                         hideWordCount: settingEntity?.hideWordCount,
                         hideHeroImage: settingEntity?.hideHeroImage,
+                        hideSummary: settingEntity?.hideSummary,
                         customCSS: settingEntity?.customCSS,
                         readerColorTheme: ReaderColorTheme(rawValue: settingEntity?.readerColorTheme ?? ReaderColorTheme.system.rawValue),
                         customBackgroundColor: settingEntity?.customBackgroundColor,

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -59,7 +59,9 @@ final class SettingsRepository: PSettingsRepository {
                         existingSettings.enableTTS = enableTTS
                     }
 
-                    existingSettings.disableReaderBackSwipe = settings.disableReaderBackSwipe
+                    if let disableReaderBackSwipe = settings.disableReaderBackSwipe {
+                        existingSettings.disableReaderBackSwipe = disableReaderBackSwipe
+                    }
 
                     if let theme = settings.theme {
                         existingSettings.theme = theme.rawValue
@@ -163,10 +165,11 @@ final class SettingsRepository: PSettingsRepository {
                     let storedFontSizeNumeric = settingEntity?.fontSizeNumeric ?? 0
                     let fontSizeNumeric: Double? = storedFontSizeNumeric > 0 ? storedFontSizeNumeric : nil
 
-                    // horizontalMargin/lineHeight: 0 means not set (use defaults)
-                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? 0
-                    let horizontalMargin: Double? = storedHorizontalMargin > 0 ? storedHorizontalMargin : nil
+                    // horizontalMargin: 0 is a valid user value (no margin), negative means not set
+                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? -1
+                    let horizontalMargin: Double? = storedHorizontalMargin >= 0 ? storedHorizontalMargin : nil
 
+                    // lineHeight: 0 is not valid, so > 0 check is correct
                     let storedLineHeight = settingEntity?.lineHeight ?? 0
                     let lineHeight: Double? = storedLineHeight > 0 ? storedLineHeight : nil
 
@@ -183,7 +186,7 @@ final class SettingsRepository: PSettingsRepository {
                         tagSortOrder: TagSortOrder(rawValue: settingEntity?.tagSortOrder ?? TagSortOrder.byCount.rawValue),
                         bookmarkSortField: BookmarkSortField(rawValue: settingEntity?.bookmarkSortField ?? BookmarkSortField.created.rawValue),
                         bookmarkSortDirection: BookmarkSortDirection(rawValue: settingEntity?.bookmarkSortDirection ?? BookmarkSortDirection.descending.rawValue),
-                        disableReaderBackSwipe: settingEntity?.disableReaderBackSwipe ?? false,
+                        disableReaderBackSwipe: settingEntity?.disableReaderBackSwipe,
                         urlOpener: UrlOpener(rawValue: settingEntity?.urlOpener ?? UrlOpener.inAppBrowser.rawValue),
                         swipeActionConfig: swipeActionConfig,
                         fontSizeNumeric: fontSizeNumeric,

--- a/readeck/Domain/Model/Settings.swift
+++ b/readeck/Domain/Model/Settings.swift
@@ -23,7 +23,7 @@ struct Settings {
     var bookmarkSortField: BookmarkSortField?
     var bookmarkSortDirection: BookmarkSortDirection?
 
-    var disableReaderBackSwipe = false
+    var disableReaderBackSwipe: Bool?
     var urlOpener: UrlOpener?
     var swipeActionConfig: SwipeActionConfig?
 

--- a/readeck/Domain/Model/Settings.swift
+++ b/readeck/Domain/Model/Settings.swift
@@ -34,6 +34,7 @@ struct Settings {
     var hideProgressBar: Bool?
     var hideWordCount: Bool?
     var hideHeroImage: Bool?
+    var hideSummary: Bool?
     var customCSS: String?
     var readerColorTheme: ReaderColorTheme?
     var customBackgroundColor: String?  // hex string

--- a/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
+++ b/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
@@ -104,7 +104,7 @@ final class SaveSettingsUseCase: PSaveSettingsUseCase {
 
     func execute(disableReaderBackSwipe: Bool) async throws {
         try await settingsRepository.saveSettings(
-            .init(disableReaderBackSwipe: disableReaderBackSwipe)
+            .init(disableReaderBackSwipe: Optional(disableReaderBackSwipe))
         )
     }
 

--- a/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
+++ b/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
@@ -4,7 +4,7 @@ protocol PSaveSettingsUseCase {
     func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize) async throws
     func execute(selectedFontFamily: FontFamily, fontSizeNumeric: Double) async throws
     func execute(readerLayout horizontalMargin: Double, lineHeight: Double) async throws
-    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool) async throws
+    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool, hideSummary: Bool) async throws
     func execute(customCSS: String) async throws
     func execute(readerColorTheme: ReaderColorTheme, customBackgroundColor: String?, customTextColor: String?) async throws
     func execute(enableTTS: Bool) async throws
@@ -49,12 +49,13 @@ final class SaveSettingsUseCase: PSaveSettingsUseCase {
         )
     }
 
-    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool) async throws {
+    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool, hideSummary: Bool) async throws {
         try await settingsRepository.saveSettings(
             .init(
                 hideProgressBar: hideProgressBar,
                 hideWordCount: hideWordCount,
-                hideHeroImage: hideHeroImage
+                hideHeroImage: hideHeroImage,
+                hideSummary: hideSummary
             )
         )
     }
@@ -104,7 +105,7 @@ final class SaveSettingsUseCase: PSaveSettingsUseCase {
 
     func execute(disableReaderBackSwipe: Bool) async throws {
         try await settingsRepository.saveSettings(
-            .init(disableReaderBackSwipe: Optional(disableReaderBackSwipe))
+            .init(disableReaderBackSwipe: disableReaderBackSwipe)
         )
     }
 

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -542,10 +542,28 @@ struct ArticleReaderLegacyView: View {
             }
             metaInfoSection
             if viewModel.canSummarize {
-                ArticleSummaryCardView(viewModel: viewModel.summaryViewModel)
+                ArticleSummaryCardView(viewModel: viewModel.summaryViewModel, backgroundColor: summaryCardBackgroundColor, textColor: nativeTextColor)
             }
         }
         .padding(.horizontal)
+    }
+
+    private var summaryCardBackgroundColor: Color {
+        let theme = viewModel.settings?.readerColorTheme ?? .system
+        switch theme {
+        case .system:
+            return Color(.secondarySystemBackground)
+        case .custom:
+            if let hex = viewModel.settings?.customBackgroundColor {
+                return Color(hex: hex).opacity(0.85)
+            }
+            return Color(.secondarySystemBackground)
+        default:
+            if let bg = theme.backgroundColor {
+                return bg.opacity(0.85)
+            }
+            return Color(.secondarySystemBackground)
+        }
     }
 
     @ViewBuilder
@@ -610,7 +628,7 @@ struct ArticleReaderLegacyView: View {
             if !viewModel.bookmarkDetail.labels.isEmpty {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "tag")
-                        .foregroundColor(.secondary)
+                        .foregroundColor(nativeSecondaryTextColor)
                         .padding(.top, 2)
 
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -619,7 +637,7 @@ struct ArticleReaderLegacyView: View {
                                 Text(label)
                                     .font(.caption)
                                     .fontWeight(.medium)
-                                    .foregroundColor(.primary)
+                                    .foregroundColor(nativeTextColor)
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 4)
                                     .background(

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -328,10 +328,28 @@ struct ArticleReaderView: View {
             }
             metaInfoSection
             if viewModel.canSummarize {
-                ArticleSummaryCardView(viewModel: viewModel.summaryViewModel)
+                ArticleSummaryCardView(viewModel: viewModel.summaryViewModel, backgroundColor: summaryCardBackgroundColor, textColor: nativeTextColor)
             }
         }
         .padding(.horizontal)
+    }
+
+    private var summaryCardBackgroundColor: Color {
+        let theme = viewModel.settings?.readerColorTheme ?? .system
+        switch theme {
+        case .system:
+            return Color(.secondarySystemBackground)
+        case .custom:
+            if let hex = viewModel.settings?.customBackgroundColor {
+                return Color(hex: hex).opacity(0.85)
+            }
+            return Color(.secondarySystemBackground)
+        default:
+            if let bg = theme.backgroundColor {
+                return bg.opacity(0.85)
+            }
+            return Color(.secondarySystemBackground)
+        }
     }
 
     private var metaInfoSection: some View {
@@ -361,7 +379,7 @@ struct ArticleReaderView: View {
             if !viewModel.bookmarkDetail.labels.isEmpty {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "tag")
-                        .foregroundColor(.secondary)
+                        .foregroundColor(nativeSecondaryTextColor)
                         .padding(.top, 2)
 
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -370,7 +388,7 @@ struct ArticleReaderView: View {
                                 Text(label)
                                     .font(.caption)
                                     .fontWeight(.medium)
-                                    .foregroundColor(.primary)
+                                    .foregroundColor(nativeTextColor)
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 4)
                                     .background(

--- a/readeck/UI/BookmarkDetail/ArticleSummaryCardView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleSummaryCardView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct ArticleSummaryCardView: View {
     @Bindable var viewModel: ArticleSummaryViewModel
+    var backgroundColor: Color = Color(.secondarySystemBackground)
+    var textColor: Color = .primary
     @State private var summaryTask: Task<Void, Never>?
 
     var body: some View {
@@ -17,7 +19,7 @@ struct ArticleSummaryCardView: View {
         }
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(Color(.secondarySystemBackground))
+                .fill(backgroundColor)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 12)
@@ -34,7 +36,7 @@ struct ArticleSummaryCardView: View {
                 .foregroundColor(.accentColor)
             Text(viewModel.hasGenerated ? "Summary".localized : "Summarize".localized)
                 .font(.subheadline.weight(.medium))
-                .foregroundColor(.primary)
+                .foregroundColor(textColor)
             Spacer()
 
             if viewModel.isLoading {
@@ -43,7 +45,7 @@ struct ArticleSummaryCardView: View {
             } else if viewModel.hasGenerated {
                 Image(systemName: viewModel.isExpanded ? "chevron.up" : "chevron.down")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(textColor.opacity(0.6))
             }
         }
         .padding(.horizontal, 14)
@@ -75,7 +77,7 @@ struct ArticleSummaryCardView: View {
                         .scaleEffect(0.8)
                     Text("Generating summary...".localized)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(textColor.opacity(0.6))
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
@@ -83,7 +85,7 @@ struct ArticleSummaryCardView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(error.localizedDescription)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(textColor.opacity(0.6))
                     Button("Retry".localized) {
                         Task { await viewModel.summarize() }
                     }
@@ -92,7 +94,7 @@ struct ArticleSummaryCardView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
             } else if !viewModel.summaryMarkdown.isEmpty {
-                MarkdownContentView(content: viewModel.summaryMarkdown)
+                MarkdownContentView(content: viewModel.summaryMarkdown, textColor: textColor)
                     .font(.subheadline)
                     .padding(.horizontal, 14)
                     .padding(.bottom, 4)

--- a/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
@@ -26,7 +26,7 @@ final class BookmarkDetailViewModel {
     var showHeroImage: Bool { settings?.hideHeroImage != true }
     var showWordCount: Bool { settings?.hideWordCount != true }
     var hasVisibleHeroImage: Bool { showHeroImage && !bookmarkDetail.imageUrl.isEmpty }
-    var canSummarize: Bool { SummarizeArticleUseCase.isAvailable && !articleContent.isEmpty }
+    var canSummarize: Bool { SummarizeArticleUseCase.isAvailable && !articleContent.isEmpty && settings?.hideSummary != true }
 
     private(set) var summaryViewModel: ArticleSummaryViewModel!
 

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -231,7 +231,7 @@ final class MockSaveSettingsUseCase: PSaveSettingsUseCase {
     func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize) async throws {}
     func execute(selectedFontFamily: FontFamily, fontSizeNumeric: Double) async throws {}
     func execute(readerLayout horizontalMargin: Double, lineHeight: Double) async throws {}
-    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool) async throws {}
+    func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool, hideSummary: Bool) async throws {}
     func execute(customCSS: String) async throws {}
     func execute(readerColorTheme: ReaderColorTheme, customBackgroundColor: String?, customTextColor: String?) async throws {}
     func execute(enableTTS: Bool) async throws {}

--- a/readeck/UI/Settings/FontSelectionView.swift
+++ b/readeck/UI/Settings/FontSelectionView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FontSelectionView: View {
     @State private var viewModel: FontSettingsViewModel
+    @State private var showCSSHelp = false
     @Environment(\.dismiss) private var dismiss
 
     init(viewModel: FontSettingsViewModel = FontSettingsViewModel()) {
@@ -101,6 +102,7 @@ struct FontSelectionView: View {
                 }
             }
             .onChange(of: viewModel.selectedFontFamily) {
+                guard !viewModel.isLoading else { return }
                 Task { await viewModel.saveFontSettings() }
             }
 
@@ -240,7 +242,7 @@ struct FontSelectionView: View {
                     value: $viewModel.horizontalMargin,
                     label: "\(Int(viewModel.horizontalMargin))px",
                     range: 0...40,
-                    step: 4
+                    step: 1
                 ) {
                     Task { await viewModel.saveReaderLayout() }
                 }
@@ -318,14 +320,17 @@ struct FontSelectionView: View {
         Section {
             Toggle("Hide progress bar", isOn: $viewModel.hideProgressBar)
                 .onChange(of: viewModel.hideProgressBar) {
+                    guard !viewModel.isLoading else { return }
                     Task { await viewModel.saveVisibilitySettings() }
                 }
             Toggle("Hide word count & reading time", isOn: $viewModel.hideWordCount)
                 .onChange(of: viewModel.hideWordCount) {
+                    guard !viewModel.isLoading else { return }
                     Task { await viewModel.saveVisibilitySettings() }
                 }
             Toggle("Hide hero image", isOn: $viewModel.hideHeroImage)
                 .onChange(of: viewModel.hideHeroImage) {
+                    guard !viewModel.isLoading else { return }
                     Task { await viewModel.saveVisibilitySettings() }
                 }
         } header: {
@@ -341,13 +346,26 @@ struct FontSelectionView: View {
                 .font(.system(.caption, design: .monospaced))
                 .frame(minHeight: 100)
                 .onChange(of: viewModel.customCSS) {
+                    guard !viewModel.isLoading else { return }
                     Task { await viewModel.saveCustomCSS() }
                 }
-            Text("Custom CSS rules appended after all default styles. Use at your own risk.")
+            Text("css.help.hint".localized)
                 .font(.caption)
                 .foregroundColor(.secondary)
         } header: {
-            Text("Custom CSS")
+            HStack {
+                Text("Custom CSS")
+                Spacer()
+                Button {
+                    showCSSHelp = true
+                } label: {
+                    Image(systemName: "questionmark.circle")
+                        .font(.subheadline)
+                }
+            }
+        }
+        .sheet(isPresented: $showCSSHelp) {
+            CustomCSSHelpView(customCSS: $viewModel.customCSS)
         }
     }
 }

--- a/readeck/UI/Settings/FontSelectionView.swift
+++ b/readeck/UI/Settings/FontSelectionView.swift
@@ -336,6 +336,11 @@ struct FontSelectionView: View {
                     guard !viewModel.isLoading else { return }
                     Task { await viewModel.saveVisibilitySettings() }
                 }
+            Toggle("Hide article summary", isOn: $viewModel.hideSummary)
+                .onChange(of: viewModel.hideSummary) {
+                    guard !viewModel.isLoading else { return }
+                    Task { await viewModel.saveVisibilitySettings() }
+                }
         } header: {
             Text("Visibility")
         }

--- a/readeck/UI/Settings/FontSelectionView.swift
+++ b/readeck/UI/Settings/FontSelectionView.swift
@@ -41,6 +41,9 @@ struct FontSelectionView: View {
         .task {
             await viewModel.loadFontSettings()
         }
+        .sheet(isPresented: $showCSSHelp) {
+            CustomCSSHelpView(customCSS: $viewModel.customCSS)
+        }
     }
 
     // MARK: - Preview
@@ -363,9 +366,6 @@ struct FontSelectionView: View {
                         .font(.subheadline)
                 }
             }
-        }
-        .sheet(isPresented: $showCSSHelp) {
-            CustomCSSHelpView(customCSS: $viewModel.customCSS)
         }
     }
 }

--- a/readeck/UI/Settings/FontSettingsView.swift
+++ b/readeck/UI/Settings/FontSettingsView.swift
@@ -24,6 +24,7 @@ struct FontSettingsView: View {
                     }
                 }
                 .onChange(of: viewModel.selectedFontFamily) {
+                    guard !viewModel.isLoading else { return }
                     Task {
                         await viewModel.saveFontSettings()
                     }
@@ -42,6 +43,7 @@ struct FontSettingsView: View {
                     }
                     Slider(value: $viewModel.fontSizeNumeric, in: 10...30, step: 1)
                         .onChange(of: viewModel.fontSizeNumeric) {
+                            guard !viewModel.isLoading else { return }
                             Task {
                                 await viewModel.saveFontSettings()
                             }
@@ -61,6 +63,7 @@ struct FontSettingsView: View {
                     }
                     Slider(value: $viewModel.horizontalMargin, in: 0...40, step: 1)
                         .onChange(of: viewModel.horizontalMargin) {
+                            guard !viewModel.isLoading else { return }
                             Task {
                                 await viewModel.saveReaderLayout()
                             }
@@ -76,6 +79,7 @@ struct FontSettingsView: View {
                     }
                     Slider(value: $viewModel.lineHeight, in: 1.0...2.5, step: 0.1)
                         .onChange(of: viewModel.lineHeight) {
+                            guard !viewModel.isLoading else { return }
                             Task {
                                 await viewModel.saveReaderLayout()
                             }
@@ -88,14 +92,17 @@ struct FontSettingsView: View {
             Section {
                 Toggle("Hide progress bar", isOn: $viewModel.hideProgressBar)
                     .onChange(of: viewModel.hideProgressBar) {
+                        guard !viewModel.isLoading else { return }
                         Task { await viewModel.saveVisibilitySettings() }
                     }
                 Toggle("Hide word count & reading time", isOn: $viewModel.hideWordCount)
                     .onChange(of: viewModel.hideWordCount) {
+                        guard !viewModel.isLoading else { return }
                         Task { await viewModel.saveVisibilitySettings() }
                     }
                 Toggle("Hide hero image", isOn: $viewModel.hideHeroImage)
                     .onChange(of: viewModel.hideHeroImage) {
+                        guard !viewModel.isLoading else { return }
                         Task { await viewModel.saveVisibilitySettings() }
                     }
             } header: {
@@ -127,6 +134,7 @@ struct FontSettingsView: View {
                     .font(.system(.caption, design: .monospaced))
                     .frame(minHeight: 100)
                     .onChange(of: viewModel.customCSS) {
+                        guard !viewModel.isLoading else { return }
                         Task { await viewModel.saveCustomCSS() }
                     }
                 Text("css.help.hint".localized)

--- a/readeck/UI/Settings/FontSettingsView.swift
+++ b/readeck/UI/Settings/FontSettingsView.swift
@@ -105,6 +105,11 @@ struct FontSettingsView: View {
                         guard !viewModel.isLoading else { return }
                         Task { await viewModel.saveVisibilitySettings() }
                     }
+                Toggle("Hide article summary", isOn: $viewModel.hideSummary)
+                    .onChange(of: viewModel.hideSummary) {
+                        guard !viewModel.isLoading else { return }
+                        Task { await viewModel.saveVisibilitySettings() }
+                    }
             } header: {
                 Text("Visibility")
             }

--- a/readeck/UI/Settings/FontSettingsViewModel.swift
+++ b/readeck/UI/Settings/FontSettingsViewModel.swift
@@ -28,6 +28,9 @@ final class FontSettingsViewModel {
     var hideWordCount: Bool = false
     var hideHeroImage: Bool = false
 
+    // MARK: - Loading State
+    var isLoading = false
+
     // MARK: - Custom CSS
     var customCSS: String = ""
 
@@ -186,6 +189,9 @@ final class FontSettingsViewModel {
 
     @MainActor
     func loadFontSettings() async {
+        isLoading = true
+        defer { isLoading = false }
+
         do {
             if let settings = try await loadSettingsUseCase.execute() {
                 selectedFontFamily = settings.fontFamily ?? .system

--- a/readeck/UI/Settings/FontSettingsViewModel.swift
+++ b/readeck/UI/Settings/FontSettingsViewModel.swift
@@ -27,6 +27,7 @@ final class FontSettingsViewModel {
     var hideProgressBar: Bool = false
     var hideWordCount: Bool = false
     var hideHeroImage: Bool = false
+    var hideSummary: Bool = false
 
     // MARK: - Loading State
     var isLoading = false
@@ -211,6 +212,7 @@ final class FontSettingsViewModel {
                 hideProgressBar = settings.hideProgressBar ?? false
                 hideWordCount = settings.hideWordCount ?? false
                 hideHeroImage = settings.hideHeroImage ?? false
+                hideSummary = settings.hideSummary ?? false
                 customCSS = settings.customCSS ?? ""
                 readerColorTheme = settings.readerColorTheme ?? .system
                 if let bgHex = settings.customBackgroundColor {
@@ -255,7 +257,8 @@ final class FontSettingsViewModel {
             try await saveSettingsUseCase.execute(
                 readerVisibility: hideProgressBar,
                 hideWordCount: hideWordCount,
-                hideHeroImage: hideHeroImage
+                hideHeroImage: hideHeroImage,
+                hideSummary: hideSummary
             )
         } catch {
             errorMessage = "Error saving visibility settings"

--- a/readeck/UI/Settings/MarkdownContentView.swift
+++ b/readeck/UI/Settings/MarkdownContentView.swift
@@ -6,10 +6,16 @@ import MarkdownUI
 /// the underlying Markdown library if needed in the future.
 struct MarkdownContentView: View {
     let content: String
+    var textColor: Color?
 
     var body: some View {
         Markdown(content)
             .textSelection(.enabled)
+            .markdownTextStyle {
+                if let textColor {
+                    ForegroundColor(textColor)
+                }
+            }
     }
 }
 

--- a/readeck/UI/Settings/ReadingSettingsView.swift
+++ b/readeck/UI/Settings/ReadingSettingsView.swift
@@ -20,6 +20,7 @@ struct ReadingSettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Listen to Article", isOn: $viewModel.enableTTS)
                         .onChange(of: viewModel.enableTTS) {
+                            guard !viewModel.isLoading else { return }
                             Task {
                                 await viewModel.saveGeneralSettings()
                             }
@@ -44,6 +45,7 @@ struct ReadingSettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Disable Back Swipe in Reader", isOn: $viewModel.disableReaderBackSwipe)
                         .onChange(of: viewModel.disableReaderBackSwipe) {
+                            guard !viewModel.isLoading else { return }
                             Task {
                                 await viewModel.saveGeneralSettings()
                             }

--- a/readeck/UI/Settings/SettingsGeneralView.swift
+++ b/readeck/UI/Settings/SettingsGeneralView.swift
@@ -35,6 +35,7 @@ struct SettingsGeneralView: View {
 
                 Toggle("Listen to Article", isOn: $viewModel.enableTTS)
                     .onChange(of: viewModel.enableTTS) {
+                        guard !viewModel.isLoading else { return }
                         Task {
                             await viewModel.saveGeneralSettings()
                         }
@@ -48,6 +49,7 @@ struct SettingsGeneralView: View {
             Section {
                 Toggle("Disable Back Swipe in Reader", isOn: $viewModel.disableReaderBackSwipe)
                     .onChange(of: viewModel.disableReaderBackSwipe) {
+                        guard !viewModel.isLoading else { return }
                         Task {
                             await viewModel.saveGeneralSettings()
                         }

--- a/readeck/UI/Settings/SettingsGeneralViewModel.swift
+++ b/readeck/UI/Settings/SettingsGeneralViewModel.swift
@@ -16,6 +16,7 @@ final class SettingsGeneralViewModel {
     var enableReaderMode = false
     var enableTTS = false
     var disableReaderBackSwipe = false
+    var isLoading = false
     var autoMarkAsRead = false
     var urlOpener: UrlOpener = .inAppBrowser
 
@@ -37,10 +38,13 @@ final class SettingsGeneralViewModel {
 
     @MainActor
     func loadGeneralSettings() async {
+        isLoading = true
+        defer { isLoading = false }
+
         do {
             if let settings = try await loadSettingsUseCase.execute() {
                 enableTTS = settings.enableTTS ?? false
-                disableReaderBackSwipe = settings.disableReaderBackSwipe
+                disableReaderBackSwipe = settings.disableReaderBackSwipe ?? false
                 selectedTheme = settings.theme ?? .system
                 urlOpener = settings.urlOpener ?? .inAppBrowser
                 bookmarkSortField = settings.bookmarkSortField ?? .created

--- a/readeck/UI/Settings/SwipeActionsSettingsView.swift
+++ b/readeck/UI/Settings/SwipeActionsSettingsView.swift
@@ -100,6 +100,14 @@ struct SwipeActionsDetailView: View {
                 }
             } header: {
                 Text("Left Swipe")
+            } footer: {
+                HStack(spacing: 4) {
+                    Image(systemName: "rectangle.lefthalf.inset.filled.arrow.left")
+                    Text("First action appears at the edge")
+                    Image(systemName: "arrow.right")
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
             }
 
             Section {
@@ -130,6 +138,14 @@ struct SwipeActionsDetailView: View {
                 }
             } header: {
                 Text("Right Swipe")
+            } footer: {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.left")
+                    Text("First action appears at the edge")
+                    Image(systemName: "rectangle.righthalf.inset.filled.arrow.right")
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
             }
 
             Section {

--- a/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
+++ b/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
@@ -70,6 +70,7 @@
         <attribute name="fontSizeNumeric" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="hideHeroImage" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="hideProgressBar" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hideSummary" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="hideWordCount" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="horizontalMargin" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lineHeight" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>


### PR DESCRIPTION
## Summary

Fixes multiple settings persistence bugs reported in #27:

- **`disableReaderBackSwipe` was reset on every partial save** — Every time font, CSS, layout, or visibility settings were saved, `disableReaderBackSwipe` was overwritten with `false` because it was a non-optional `Bool` and the repository always wrote it unconditionally. Now `Bool?` with `if let` guard.
- **onChange fired during initial load** — When settings were loaded, property changes triggered `onChange` handlers which caused unnecessary (and harmful) saves. All handlers now have `guard !viewModel.isLoading` checks.
- **`horizontalMargin=0` treated as "not set"** — The `> 0` check in `loadSettings()` discarded valid 0 values. Changed to `>= 0`.
- **Margin step was 4 instead of 1** — `FontSelectionView` (the actual reader sheet) used `step: 4`. Changed to `step: 1`.
- **CSS help/snippets not reachable from reader** — `FontSelectionView` was missing the `?` button to open `CustomCSSHelpView` with the snippet library.

## Test plan

- [ ] Set "Disable Back Swipe" to ON, change font settings, verify toggle stays ON
- [ ] Set horizontal margin to 0px, close and reopen settings, verify it stays at 0
- [ ] Verify margin stepper increments by 1px
- [ ] Open reader settings sheet, verify CSS help button (`?`) is visible and opens snippet library
- [ ] Change custom CSS, close sheet, reopen article — verify CSS is applied
- [ ] Scroll settings list so "Disable Back Swipe" goes off-screen, scroll back — verify it keeps its value