### PR TITLE
fix: apply tag sort order reactively in label management (#43)

### DIFF
--- a/URLShare/ShareBookmarkViewModel.swift
+++ b/URLShare/ShareBookmarkViewModel.swift
@@ -15,7 +15,7 @@ final class ShareBookmarkViewModel: ObservableObject {
     @Published var sessionExpired = false
     @Published var pageHTML: String?
     @Published var includeHTML = false
-    let tagSortOrder: TagSortOrder = .byCount  // Share Extension always uses byCount
+    let tagSortOrder: TagSortOrder
     let extensionContext: NSExtensionContext?
 
     private let logger = Logger.viewModel
@@ -25,6 +25,7 @@ final class ShareBookmarkViewModel: ObservableObject {
 
     init(extensionContext: NSExtensionContext?) {
         self.extensionContext = extensionContext
+        self.tagSortOrder = Self.loadTagSortOrder()
         logger.info("ShareBookmarkViewModel initialized with extension context: \(extensionContext != nil)")
 
         // Check if app is configured by verifying token exists
@@ -261,5 +262,20 @@ final class ShareBookmarkViewModel: ObservableObject {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    private static func loadTagSortOrder() -> TagSortOrder {
+        let context = CoreDataManager.shared.context
+        var result: TagSortOrder = .byCount
+        context.performAndWait {
+            let fetchRequest: NSFetchRequest<SettingEntity> = SettingEntity.fetchRequest()
+            fetchRequest.fetchLimit = 1
+            if let entity = try? context.fetch(fetchRequest).first,
+               let raw = entity.tagSortOrder,
+               let parsed = TagSortOrder(rawValue: raw) {
+                result = parsed
+            }
+        }
+        return result
     }
 }

--- a/readeck/UI/Components/CoreDataTagManagementView.swift
+++ b/readeck/UI/Components/CoreDataTagManagementView.swift
@@ -52,21 +52,7 @@ struct CoreDataTagManagementView: View {
         self.onRemoveLabel = onRemoveLabel
 
         let fetchRequest: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
-
-        // Apply sort order from parameter
-        let sortDescriptors: [NSSortDescriptor]
-        switch sortOrder {
-        case .byCount:
-            sortDescriptors = [
-                NSSortDescriptor(keyPath: \TagEntity.count, ascending: false),
-                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
-            ]
-        case .alphabetically:
-            sortDescriptors = [
-                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
-            ]
-        }
-        fetchRequest.sortDescriptors = sortDescriptors
+        fetchRequest.sortDescriptors = Self.sortDescriptors(for: sortOrder)
 
         if let limit = fetchLimit {
             fetchRequest.fetchLimit = limit
@@ -88,6 +74,26 @@ struct CoreDataTagManagementView: View {
         }
         .onChange(of: searchText.wrappedValue) { _, newValue in
             performSearch(query: newValue)
+        }
+        .onChange(of: sortOrder) { _, newValue in
+            tagEntities.nsSortDescriptors = Self.sortDescriptors(for: newValue)
+            if isSearchActive {
+                performSearch(query: searchText.wrappedValue)
+            }
+        }
+    }
+
+    private static func sortDescriptors(for sortOrder: TagSortOrder) -> [NSSortDescriptor] {
+        switch sortOrder {
+        case .byCount:
+            return [
+                NSSortDescriptor(keyPath: \TagEntity.count, ascending: false),
+                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
+            ]
+        case .alphabetically:
+            return [
+                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
+            ]
         }
     }
 
@@ -277,20 +283,7 @@ struct CoreDataTagManagementView: View {
         let fetchRequest: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "name CONTAINS[cd] %@", query)
 
-        // Use same sort order as main fetch
-        let sortDescriptors: [NSSortDescriptor]
-        switch sortOrder {
-        case .byCount:
-            sortDescriptors = [
-                NSSortDescriptor(keyPath: \TagEntity.count, ascending: false),
-                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
-            ]
-        case .alphabetically:
-            sortDescriptors = [
-                NSSortDescriptor(keyPath: \TagEntity.name, ascending: true)
-            ]
-        }
-        fetchRequest.sortDescriptors = sortDescriptors
+        fetchRequest.sortDescriptors = Self.sortDescriptors(for: sortOrder)
 
         // NO fetchLimit - search ALL tags in database
         searchResults = (try? context.fetch(fetchRequest)) ?? []


### PR DESCRIPTION
Closes #43

## Summary
Switching the tag sort order in Settings from "by usage count" to "alphabetically" had no visible effect on the label grid in Add/Manage Bookmark Labels — even after an app restart.

## Root cause
`CoreDataTagManagementView` built its `NSFetchRequest` sort descriptors once in `init` and assigned `_tagEntities = FetchRequest(...)`. SwiftUI's `@FetchRequest` backing store is tied to view identity and persists across view struct re-inits, so later changes to the `sortOrder` parameter (including async settings load on launch) did not reach the live fetch request.

## Fix
- Extract sort descriptors into a `static` helper to avoid duplication.
- React to `sortOrder` changes via `.onChange(of: sortOrder)` and update `tagEntities.nsSortDescriptors` live.
- Re-run the active search with the new descriptors so search results also re-sort.

## Test plan
- [x] Fresh install: set sort to "Alphabetically" in Settings → Appearance, open a bookmark's labels, verify grid is alphabetical.
- [x] Toggle between "By usage count" and "Alphabetically" while a bookmark label sheet is open → grid updates immediately.
- [x] Set "Alphabetically", cold-launch the app, open labels → still alphabetical.
- [x] Type into the search field → results respect the active sort order.