### PR TITLE
fix: decode nested version object in share extension server check

### DIFF
--- a/URLShare/ShareBookmarkViewModel.swift
+++ b/URLShare/ShareBookmarkViewModel.swift
@@ -116,13 +116,13 @@ final class ShareBookmarkViewModel: ObservableObject {
         // Check server connectivity
         Task {
             let serverInfo = await serverCheck.checkServerReachability()
-            logger.debug("Server connectivity for save: \(serverInfo != nil), version: \(serverInfo?.version ?? "unknown")")
+            logger.debug("Server connectivity for save: \(serverInfo != nil), version: \(serverInfo?.version.canonical ?? "unknown")")
             if let serverInfo {
                 // Online - try to save via API
                 logger.info("Attempting to save bookmark via API")
                 let htmlToSend = includeHTML && serverInfo.supportsHTMLBookmarks ? pageHTML : nil
                 if includeHTML && !serverInfo.supportsHTMLBookmarks {
-                    logger.info("Server version \(serverInfo.version) does not support HTML bookmarks (requires >= 0.22), sending without HTML")
+                    logger.info("Server version \(serverInfo.version.canonical) does not support HTML bookmarks (requires >= 0.22), sending without HTML")
                 }
                 await SimpleAPI.addBookmark(title: title, url: url, labels: Array(selectedLabels), html: htmlToSend) { [weak self] message, error in
                     self?.logger.info("API save completed - Success: \(!error), Message: \(message)")

--- a/URLShare/SimpleAPIDTOs.swift
+++ b/URLShare/SimpleAPIDTOs.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 public struct ServerInfoDto: Codable {
-    public let version: String
-    public let buildDate: String?
-    public let userAgent: String?
+    public let version: VersionInfo
+    // swiftlint:disable:next discouraged_optional_collection
+    public let features: [String]?
 
-    public enum CodingKeys: String, CodingKey {
-        case version
-        case buildDate = "build_date"
-        case userAgent = "user_agent"
+    public struct VersionInfo: Codable {
+        public let canonical: String
+        public let release: String?
+        public let build: String?
     }
 
     // HTML bookmark submission requires Readeck >= 0.22
     public var supportsHTMLBookmarks: Bool {
-        let parts = version.split(separator: ".").compactMap { Int($0) }
+        let parts = version.canonical.split(separator: ".").compactMap { Int($0) }
         guard parts.count >= 2 else { return false }
         return parts[0] > 0 || parts[1] >= 22
     }

--- a/readeckTests/Domain/ServerInfoTests.swift
+++ b/readeckTests/Domain/ServerInfoTests.swift
@@ -5,6 +5,7 @@
 //  Created by Ilyas Hallak on 15.12.25.
 //
 
+import Foundation
 import Testing
 @testable import readeck
 
@@ -186,5 +187,28 @@ struct ServerInfoTests {
         #expect(serverInfo != nil)
         #expect(!serverInfo.supportsOAuth, "Server with features but no oauth should report no OAuth support")
         #expect(serverInfo.supportsEmail)
+    }
+
+    // MARK: - JSON Decoding
+
+    @Test("Decodes real server /api/info response with nested version object")
+    func decode_RealServerResponse_WithNestedVersion() throws {
+        let json = """
+        {
+          "version": {
+            "canonical": "0.22.2",
+            "release": "0.22.2",
+            "build": ""
+          },
+          "features": ["oauth"]
+        }
+        """.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(ServerInfoDto.self, from: json)
+
+        #expect(dto.version.canonical == "0.22.2")
+        #expect(dto.version.release == "0.22.2")
+        #expect(dto.version.build == "")
+        #expect(dto.features == ["oauth"])
     }
 }


### PR DESCRIPTION
## Summary
- Share Extension meldete „Server nicht erreichbar", obwohl der Server antwortete
- Ursache: `URLShare/SimpleAPIDTOs.swift` erwartete `version` als `String`, der Server liefert jedoch ein Objekt `{canonical, release, build}`. Das JSON-Decoding schlug still (`try?`) fehl → `checkServerReachability()` gab `nil` zurück → Fallback auf lokales Offline-Speichern
- DTO an das echte Server-Schema angepasst, Log-Zugriffe auf `version.canonical` umgestellt, Decoding-Test für die reale `/api/info`-Antwort ergänzt

## Test plan
- [ ] Unit-Test `decode_RealServerResponse_WithNestedVersion` läuft grün
- [ ] Share Extension mit Readeck-Server 0.22.x manuell testen: Lesezeichen wird online (nicht offline) gespeichert
- [ ] Regressionscheck: Share Extension ohne Netz/Server weiterhin lokal speichernd