### PR TITLE
fix: highlights appear immediately after creation (#37)

### DIFF
--- a/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
@@ -267,6 +267,7 @@ final class BookmarkDetailViewModel {
             Logger.viewModel.info("✅ Annotation created: \(annotation.id)")
             annotations.append(annotation)
             hasAnnotations = true
+            await refreshArticleInBackground(id: bookmarkId)
         } catch {
             Logger.viewModel.error("❌ Failed to create annotation: \(error.localizedDescription)")
             // Check for specific error messages from server


### PR DESCRIPTION
Fixes #37

## Summary
- On iPad, freshly created highlights were not visible until the user opened/closed the Annotations sheet (which triggered a server refresh).
- Local JS `surroundContents` wrapping fails silently on complex selections, so nothing visible was inserted into the DOM.
- Fix: refresh article HTML from the server right after a successful `createAnnotation`. Works for both `NativeWebView` (iOS 26+) and the legacy `WebView` since the change lives in the ViewModel.

## Test plan
- [ ] Highlight text on iPad — appears immediately
- [ ] iPhone behavior unchanged
- [ ] Multiple consecutive highlights work
- [ ] Scroll position preserved