### PR TITLE
Recover bookmark article HTML when GET /article returns 502

### DIFF
--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -340,141 +340,6 @@ final class API: PAPI {
 
     // MARK: - Bookmark article (GET + 502 recovery)
 
-    private enum BookmarkArticleGETOutcome {
-        case success(String)
-        case badGateway
-        case httpFailure(statusCode: Int)
-    }
-
-    private struct BookmarkSyncRequestBody: Encodable {
-        let id: [String]
-        let with_json: Bool
-        let with_html: Bool
-        let with_resources: Bool
-        let resource_prefix: String
-
-        init(bookmarkId: String) {
-            id = [bookmarkId]
-            with_json = false
-            with_html = true
-            with_resources = false
-            resource_prefix = "."
-        }
-    }
-
-    private func fetchBookmarkArticleGETOutcome(
-        endpoint: String,
-        timeout: TimeInterval,
-        additionalHeaders: [String: String]
-    ) async throws -> BookmarkArticleGETOutcome {
-        var request = try await buildRequest(
-            url: endpoint,
-            method: .GET,
-            body: nil,
-            useBaseURL: true,
-            additionalHeaders: additionalHeaders
-        )
-        request.timeoutInterval = timeout
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            logger.error("Invalid HTTP response for \(endpoint)")
-            throw APIError.invalidResponse
-        }
-
-        if httpResponse.statusCode == 502 {
-            return .badGateway
-        }
-
-        guard 200...299 ~= httpResponse.statusCode else {
-            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
-            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
-            return .httpFailure(statusCode: httpResponse.statusCode)
-        }
-
-        guard let string = String(data: data, encoding: .utf8) else {
-            logger.error("Unable to decode response as UTF-8 string for \(endpoint)")
-            logger.error("Data size: \(data.count) bytes")
-            throw APIError.invalidResponse
-        }
-
-        return .success(string)
-    }
-
-    private func fetchBookmarkArticleRecoveringFrom502(id: String, endpoint: String, timeout: TimeInterval) async throws -> String {
-        switch try await fetchBookmarkArticleGETOutcome(endpoint: endpoint, timeout: timeout, additionalHeaders: [:]) {
-        case let .success(html):
-            logger.debug("Bookmark article fetch path: GET /article")
-            return html
-        case .badGateway:
-            break
-        case let .httpFailure(statusCode):
-            handleUnauthorizedResponse(statusCode)
-            throw APIError.serverError(statusCode)
-        }
-
-        switch try await fetchBookmarkArticleGETOutcome(
-            endpoint: endpoint,
-            timeout: timeout,
-            additionalHeaders: ["Accept-Encoding": "gzip, deflate, br"]
-        ) {
-        case let .success(html):
-            logger.info("Bookmark article fetch path: GET /article with Accept-Encoding after 502")
-            return html
-        case .badGateway:
-            break
-        case let .httpFailure(statusCode):
-            handleUnauthorizedResponse(statusCode)
-            throw APIError.serverError(statusCode)
-        }
-
-        logger.info("Bookmark article fetch path: POST /bookmarks/sync multipart fallback")
-        return try await fetchBookmarkArticleThroughSync(bookmarkId: id, timeout: timeout)
-    }
-
-    private func fetchBookmarkArticleThroughSync(bookmarkId: String, timeout: TimeInterval) async throws -> String {
-        let endpoint = "/api/bookmarks/sync"
-        let bodyData = try JSONEncoder().encode(BookmarkSyncRequestBody(bookmarkId: bookmarkId))
-
-        var request = try await buildRequest(
-            url: endpoint,
-            method: .POST,
-            body: bodyData,
-            useBaseURL: true
-        )
-        request.timeoutInterval = timeout
-
-        let baseURL = await self.baseURL
-        let fullURL = "\(baseURL)\(endpoint)"
-        logger.logNetworkRequest(method: "POST", url: fullURL)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            logger.error("Invalid HTTP response for sync article fallback")
-            throw APIError.invalidResponse
-        }
-
-        guard 200...299 ~= httpResponse.statusCode else {
-            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
-            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
-            handleUnauthorizedResponse(httpResponse.statusCode)
-            throw APIError.serverError(httpResponse.statusCode)
-        }
-
-        logger.logNetworkRequest(method: "POST", url: fullURL, statusCode: httpResponse.statusCode)
-
-        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
-        do {
-            return try MultipartMixedHTMLExtractor.extractHTML(data: data, contentTypeValue: contentType, bookmarkId: bookmarkId)
-        } catch {
-            logger.error("Failed to parse sync multipart HTML: \(error)")
-            throw APIError.invalidResponse
-        }
-    }
-
-    // Artikel als String laden statt als JSON
     func getBookmarkArticle(id: String) async throws -> String {
         logger.debug("Fetching article for bookmark: \(id)")
         let endpoint = "/api/bookmarks/\(id)/article"
@@ -522,6 +387,118 @@ final class API: PAPI {
         }
 
         throw APIError.invalidResponse
+    }
+
+    private func fetchBookmarkArticleRecoveringFrom502(id: String, endpoint: String, timeout: TimeInterval) async throws -> String {
+        switch try await fetchBookmarkArticleGETOutcome(endpoint: endpoint, timeout: timeout, additionalHeaders: [:]) {
+        case let .success(html):
+            logger.debug("Bookmark article fetch path: GET /article")
+            return html
+        case .badGateway:
+            break
+        case let .httpFailure(statusCode):
+            handleUnauthorizedResponse(statusCode)
+            throw APIError.serverError(statusCode)
+        }
+
+        switch try await fetchBookmarkArticleGETOutcome(
+            endpoint: endpoint,
+            timeout: timeout,
+            additionalHeaders: ["Accept-Encoding": "gzip, deflate, br"]
+        ) {
+        case let .success(html):
+            logger.info("Bookmark article fetch path: GET /article with Accept-Encoding after 502")
+            return html
+        case .badGateway:
+            break
+        case let .httpFailure(statusCode):
+            handleUnauthorizedResponse(statusCode)
+            throw APIError.serverError(statusCode)
+        }
+
+        logger.info("Bookmark article fetch path: POST /bookmarks/sync multipart fallback")
+        return try await fetchBookmarkArticleThroughSync(bookmarkId: id, timeout: timeout)
+    }
+
+    private func fetchBookmarkArticleGETOutcome(
+        endpoint: String,
+        timeout: TimeInterval,
+        additionalHeaders: [String: String]
+    ) async throws -> BookmarkArticleGETOutcome {
+        var request = try await buildRequest(
+            url: endpoint,
+            method: .GET,
+            body: nil,
+            useBaseURL: true,
+            additionalHeaders: additionalHeaders
+        )
+        request.timeoutInterval = timeout
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            logger.error("Invalid HTTP response for \(endpoint)")
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 502 {
+            return .badGateway
+        }
+
+        guard 200...299 ~= httpResponse.statusCode else {
+            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
+            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
+            return .httpFailure(statusCode: httpResponse.statusCode)
+        }
+
+        guard let string = String(data: data, encoding: .utf8) else {
+            logger.error("Unable to decode response as UTF-8 string for \(endpoint)")
+            logger.error("Data size: \(data.count) bytes")
+            throw APIError.invalidResponse
+        }
+
+        return .success(string)
+    }
+
+    private func fetchBookmarkArticleThroughSync(bookmarkId: String, timeout: TimeInterval) async throws -> String {
+        let endpoint = "/api/bookmarks/sync"
+        let bodyData = try JSONEncoder().encode(BookmarkSyncRequestBody(bookmarkId: bookmarkId))
+
+        var request = try await buildRequest(
+            url: endpoint,
+            method: .POST,
+            body: bodyData,
+            useBaseURL: true
+        )
+        request.timeoutInterval = timeout
+
+        let baseURL = await self.baseURL
+        let fullURL = "\(baseURL)\(endpoint)"
+        logger.logNetworkRequest(method: "POST", url: fullURL)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            logger.error("Invalid HTTP response for sync article fallback")
+            throw APIError.invalidResponse
+        }
+
+        guard 200...299 ~= httpResponse.statusCode else {
+            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
+            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
+            handleUnauthorizedResponse(httpResponse.statusCode)
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+
+        logger.logNetworkRequest(method: "POST", url: fullURL, statusCode: httpResponse.statusCode)
+
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+        do {
+            return try MultipartMixedHTMLExtractor.extractHTML(data: data, contentTypeValue: contentType, bookmarkId: bookmarkId)
+        } catch {
+            logger.error("Failed to parse sync multipart HTML: \(error)")
+            throw APIError.invalidResponse
+        }
     }
 
     func createBookmark(createRequest: CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto {

--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -168,14 +168,19 @@ final class API: PAPI {
     // Separate Methode für String-Requests (HTML/Text)
     private func makeStringRequest(
         endpoint: String,
-        method: HTTPMethod = .GET
+        method: HTTPMethod = .GET,
+        timeoutInterval: TimeInterval? = nil
     ) async throws -> String {
-        let request = try await buildRequest(
+        var request = try await buildRequest(
             url: endpoint,
             method: method,
             body: nil,
             useBaseURL: true
         )
+
+        if let timeoutInterval {
+            request.timeoutInterval = timeoutInterval
+        }
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -333,18 +338,190 @@ final class API: PAPI {
         return result
     }
 
+    // MARK: - Bookmark article (GET + 502 recovery)
+
+    private enum BookmarkArticleGETOutcome {
+        case success(String)
+        case badGateway
+        case httpFailure(statusCode: Int)
+    }
+
+    private struct BookmarkSyncRequestBody: Encodable {
+        let id: [String]
+        let with_json: Bool
+        let with_html: Bool
+        let with_resources: Bool
+        let resource_prefix: String
+
+        init(bookmarkId: String) {
+            id = [bookmarkId]
+            with_json = false
+            with_html = true
+            with_resources = false
+            resource_prefix = "."
+        }
+    }
+
+    private func fetchBookmarkArticleGETOutcome(
+        endpoint: String,
+        timeout: TimeInterval,
+        additionalHeaders: [String: String]
+    ) async throws -> BookmarkArticleGETOutcome {
+        var request = try await buildRequest(
+            url: endpoint,
+            method: .GET,
+            body: nil,
+            useBaseURL: true,
+            additionalHeaders: additionalHeaders
+        )
+        request.timeoutInterval = timeout
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            logger.error("Invalid HTTP response for \(endpoint)")
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 502 {
+            return .badGateway
+        }
+
+        guard 200...299 ~= httpResponse.statusCode else {
+            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
+            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
+            return .httpFailure(statusCode: httpResponse.statusCode)
+        }
+
+        guard let string = String(data: data, encoding: .utf8) else {
+            logger.error("Unable to decode response as UTF-8 string for \(endpoint)")
+            logger.error("Data size: \(data.count) bytes")
+            throw APIError.invalidResponse
+        }
+
+        return .success(string)
+    }
+
+    private func fetchBookmarkArticleRecoveringFrom502(id: String, endpoint: String, timeout: TimeInterval) async throws -> String {
+        switch try await fetchBookmarkArticleGETOutcome(endpoint: endpoint, timeout: timeout, additionalHeaders: [:]) {
+        case let .success(html):
+            logger.debug("Bookmark article fetch path: GET /article")
+            return html
+        case .badGateway:
+            break
+        case let .httpFailure(statusCode):
+            handleUnauthorizedResponse(statusCode)
+            throw APIError.serverError(statusCode)
+        }
+
+        switch try await fetchBookmarkArticleGETOutcome(
+            endpoint: endpoint,
+            timeout: timeout,
+            additionalHeaders: ["Accept-Encoding": "gzip, deflate, br"]
+        ) {
+        case let .success(html):
+            logger.info("Bookmark article fetch path: GET /article with Accept-Encoding after 502")
+            return html
+        case .badGateway:
+            break
+        case let .httpFailure(statusCode):
+            handleUnauthorizedResponse(statusCode)
+            throw APIError.serverError(statusCode)
+        }
+
+        logger.info("Bookmark article fetch path: POST /bookmarks/sync multipart fallback")
+        return try await fetchBookmarkArticleThroughSync(bookmarkId: id, timeout: timeout)
+    }
+
+    private func fetchBookmarkArticleThroughSync(bookmarkId: String, timeout: TimeInterval) async throws -> String {
+        let endpoint = "/api/bookmarks/sync"
+        let bodyData = try JSONEncoder().encode(BookmarkSyncRequestBody(bookmarkId: bookmarkId))
+
+        var request = try await buildRequest(
+            url: endpoint,
+            method: .POST,
+            body: bodyData,
+            useBaseURL: true
+        )
+        request.timeoutInterval = timeout
+
+        let baseURL = await self.baseURL
+        let fullURL = "\(baseURL)\(endpoint)"
+        logger.logNetworkRequest(method: "POST", url: fullURL)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            logger.error("Invalid HTTP response for sync article fallback")
+            throw APIError.invalidResponse
+        }
+
+        guard 200...299 ~= httpResponse.statusCode else {
+            logger.error("Server error for \(endpoint): HTTP \(httpResponse.statusCode)")
+            logger.error("Response data: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
+            handleUnauthorizedResponse(httpResponse.statusCode)
+            throw APIError.serverError(httpResponse.statusCode)
+        }
+
+        logger.logNetworkRequest(method: "POST", url: fullURL, statusCode: httpResponse.statusCode)
+
+        let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+        do {
+            return try MultipartMixedHTMLExtractor.extractHTML(data: data, contentTypeValue: contentType, bookmarkId: bookmarkId)
+        } catch {
+            logger.error("Failed to parse sync multipart HTML: \(error)")
+            throw APIError.invalidResponse
+        }
+    }
+
     // Artikel als String laden statt als JSON
     func getBookmarkArticle(id: String) async throws -> String {
         logger.debug("Fetching article for bookmark: \(id)")
         let endpoint = "/api/bookmarks/\(id)/article"
-        logger.logNetworkRequest(method: "GET", url: await self.baseURL + endpoint)
+        // Proxied instances may return transient 502/503/504 while the origin is slow or busy.
+        let requestTimeout: TimeInterval = 300
+        let maxAttempts = 4
 
-        let result = try await makeStringRequest(
-            endpoint: endpoint
-        )
+        for attempt in 1...maxAttempts {
+            logger.logNetworkRequest(method: "GET", url: await self.baseURL + endpoint)
+            if attempt > 1 {
+                logger.info("Retrying article fetch for bookmark \(id) (attempt \(attempt) of \(maxAttempts))")
+            }
 
-        logger.info("Successfully fetched article for bookmark: \(id)")
-        return result
+            do {
+                let result = try await fetchBookmarkArticleRecoveringFrom502(
+                    id: id,
+                    endpoint: endpoint,
+                    timeout: requestTimeout
+                )
+                logger.info("Successfully fetched article for bookmark: \(id)")
+                return result
+            } catch {
+                let apiStatus: Int? = {
+                    guard let apiError = error as? APIError else { return nil }
+                    if case .serverError(let code) = apiError { return code }
+                    return nil
+                }()
+                let isTransientHTTP = apiStatus.map { [502, 503, 504].contains($0) } ?? false
+                let isTimeout = (error as? URLError)?.code == .timedOut
+                let canRetry = attempt < maxAttempts && (isTransientHTTP || isTimeout)
+
+                guard canRetry else {
+                    throw error
+                }
+
+                if let status = apiStatus {
+                    logger.warning("Transient HTTP \(status) loading article \(id); backing off before retry")
+                } else {
+                    logger.warning("Request timed out loading article \(id); backing off before retry")
+                }
+
+                let backoffSeconds = pow(2.0, Double(attempt - 1)) * 0.5 + Double.random(in: 0...0.25)
+                try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+            }
+        }
+
+        throw APIError.invalidResponse
     }
 
     func createBookmark(createRequest: CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto {

--- a/readeck/Data/API/BookmarkArticleGETOutcome.swift
+++ b/readeck/Data/API/BookmarkArticleGETOutcome.swift
@@ -1,0 +1,10 @@
+//
+//  BookmarkArticleGETOutcome.swift
+//  readeck
+//
+
+enum BookmarkArticleGETOutcome {
+    case success(String)
+    case badGateway
+    case httpFailure(statusCode: Int)
+}

--- a/readeck/Data/API/DTOs/BookmarkSyncRequestBody.swift
+++ b/readeck/Data/API/DTOs/BookmarkSyncRequestBody.swift
@@ -1,0 +1,20 @@
+//
+//  BookmarkSyncRequestBody.swift
+//  readeck
+//
+
+struct BookmarkSyncRequestBody: Encodable {
+    let id: [String]
+    let with_json: Bool
+    let with_html: Bool
+    let with_resources: Bool
+    let resource_prefix: String
+
+    init(bookmarkId: String) {
+        id = [bookmarkId]
+        with_json = false
+        with_html = true
+        with_resources = false
+        resource_prefix = "."
+    }
+}

--- a/readeck/Data/API/MultipartMixedHTMLExtractor.swift
+++ b/readeck/Data/API/MultipartMixedHTMLExtractor.swift
@@ -1,0 +1,95 @@
+//
+//  MultipartMixedHTMLExtractor.swift
+//  readeck
+//
+
+import Foundation
+
+/// Extracts the `Type: html` part for a given bookmark from a Readeck `POST /api/bookmarks/sync` body (`multipart/mixed`).
+enum MultipartMixedHTMLExtractor {
+
+    enum ExtractError: Error {
+        case noBoundary
+        case invalidEncoding
+        case noHTMLPart
+    }
+
+    static func extractHTML(data: Data, contentTypeValue: String?, bookmarkId: String) throws -> String {
+        guard let contentTypeValue else { throw ExtractError.noBoundary }
+        guard let boundary = parseBoundary(from: contentTypeValue) else { throw ExtractError.noBoundary }
+        guard let string = String(data: data, encoding: .utf8) else { throw ExtractError.invalidEncoding }
+        return try extractHTML(string: string, boundary: boundary, bookmarkId: bookmarkId)
+    }
+
+    static func parseBoundary(from contentType: String) -> String? {
+        let lower = contentType.lowercased()
+        guard let r = lower.range(of: "boundary=") else { return nil }
+        var tail = String(contentType[r.upperBound...]).trimmingCharacters(in: .whitespaces)
+        if tail.hasPrefix("\"") {
+            tail.removeFirst()
+            if let endQuote = tail.firstIndex(of: "\"") {
+                return String(tail[..<endQuote])
+            }
+        }
+        if let semi = tail.firstIndex(of: ";") {
+            tail = String(tail[..<semi])
+        }
+        return tail.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func extractHTML(string: String, boundary: String, bookmarkId: String) throws -> String {
+        let opening = "--\(boundary)\r\n"
+        let openingLF = "--\(boundary)\n"
+        var inner = string
+        if inner.hasPrefix(opening) {
+            inner.removeFirst(opening.count)
+        } else if inner.hasPrefix(openingLF) {
+            inner.removeFirst(openingLF.count)
+        } else {
+            throw ExtractError.noBoundary
+        }
+
+        let partSeparator = "\r\n--\(boundary)\r\n"
+        var segments = inner.components(separatedBy: partSeparator)
+        let closingOnly = "--\(boundary)--"
+        let closingWithCRLF = "\r\n--\(boundary)--"
+
+        for (index, var segment) in segments.enumerated() {
+            segment = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            if index == segments.count - 1 {
+                if segment.hasSuffix(closingWithCRLF) {
+                    segment = String(segment.dropLast(closingWithCRLF.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if segment.hasSuffix(closingOnly) {
+                    segment = String(segment.dropLast(closingOnly.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+
+            guard let headerEnd = segment.range(of: "\r\n\r\n") else { continue }
+            let headerString = String(segment[..<headerEnd.lowerBound])
+            var body = String(segment[headerEnd.upperBound...])
+            body = body.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let headers = parsePartHeaders(headerString)
+            let typeValue = headers["type"]?.lowercased()
+            let idValue = headers["bookmark-id"]
+
+            if typeValue == "html", idValue == bookmarkId {
+                return body
+            }
+        }
+
+        throw ExtractError.noHTMLPart
+    }
+
+    private static func parsePartHeaders(_ block: String) -> [String: String] {
+        var out: [String: String] = [:]
+        let lines = block.components(separatedBy: "\r\n")
+        for line in lines where !line.isEmpty {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = String(line[..<colon]).trimmingCharacters(in: .whitespaces).lowercased()
+            let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            out[name] = value
+        }
+        return out
+    }
+}

--- a/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
+++ b/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
@@ -1,0 +1,172 @@
+//
+//  BookmarkArticleRecoveryAPITests.swift
+//  readeckTests
+//
+
+import XCTest
+@testable import readeck
+
+private final class ArticleRecoveryURLProtocol: URLProtocol {
+
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    /// `URLSession` may supply `httpBodyStream` instead of `httpBody` for POST requests.
+    private static func requestBodyData(for request: URLRequest) -> Data {
+        if let body = request.httpBody, !body.isEmpty { return body }
+        guard let stream = request.httpBodyStream else { return Data() }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read < 0 { break }
+            if read == 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "mock.example.com"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        do {
+            var canonical = request
+            if canonical.httpBody == nil || canonical.httpBody?.isEmpty == true {
+                let body = Self.requestBodyData(for: canonical)
+                canonical.httpBody = body
+            }
+            let (response, data) = try handler(canonical)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class BookmarkArticleRecoveryAPITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(ArticleRecoveryURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(ArticleRecoveryURLProtocol.self)
+        ArticleRecoveryURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testGetBookmarkArticle_502_thenGzipRetryReturns200() async throws {
+        ArticleRecoveryURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            XCTAssertTrue(path.contains("/article"))
+            let enc = request.value(forHTTPHeaderField: "Accept-Encoding") ?? ""
+            if !enc.contains("gzip") {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 502,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (response, Data("bad".utf8))
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/html; charset=utf-8"]
+            )!
+            return (response, "<p>ok</p>".data(using: .utf8)!)
+        }
+
+        let api = API(tokenProvider: TestMockTokenProvider())
+        let html = try await api.getBookmarkArticle(id: "bm1")
+        XCTAssertEqual(html, "<p>ok</p>")
+    }
+
+    func testGetBookmarkArticle_double502_thenSyncMultipartReturnsHTML() async throws {
+        let boundary = "sep9"
+        let multipartBody = [
+            "--\(boundary)",
+            "Type: html",
+            "Bookmark-Id: bm1",
+            "",
+            "<article>x</article>",
+            "--\(boundary)--",
+            ""
+        ].joined(separator: "\r\n")
+
+        ArticleRecoveryURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/article") {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 502,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (response, Data())
+            }
+            if path.hasSuffix("/sync") {
+                XCTAssertEqual(request.httpMethod, "POST")
+                let bodyString = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                XCTAssertTrue(bodyString.contains("\"with_html\":true"))
+                XCTAssertTrue(bodyString.contains("\"with_json\":false"))
+                XCTAssertTrue(bodyString.contains("\"with_resources\":false"))
+                XCTAssertTrue(bodyString.contains("bm1"))
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+                )!
+                return (response, Data(multipartBody.utf8))
+            }
+            XCTFail("Unexpected path: \(path)")
+            throw URLError(.badURL)
+        }
+
+        let api = API(tokenProvider: TestMockTokenProvider())
+        let html = try await api.getBookmarkArticle(id: "bm1")
+        XCTAssertEqual(html, "<article>x</article>")
+    }
+
+    func testGetBookmarkArticle_allPathsFail_throws502() async throws {
+        ArticleRecoveryURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 502,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let api = API(tokenProvider: TestMockTokenProvider())
+        do {
+            _ = try await api.getBookmarkArticle(id: "bm1")
+            XCTFail("Expected error")
+        } catch let error as APIError {
+            if case .serverError(let code) = error {
+                XCTAssertEqual(code, 502)
+            } else {
+                XCTFail("Wrong error \(error)")
+            }
+        }
+    }
+}

--- a/readeckTests/API/MultipartMixedHTMLExtractorTests.swift
+++ b/readeckTests/API/MultipartMixedHTMLExtractorTests.swift
@@ -1,0 +1,44 @@
+//
+//  MultipartMixedHTMLExtractorTests.swift
+//  readeckTests
+//
+
+import XCTest
+@testable import readeck
+
+final class MultipartMixedHTMLExtractorTests: XCTestCase {
+
+    func testParseBoundaryQuoted() {
+        let ct = #"multipart/mixed; boundary="abc-123""#
+        XCTAssertEqual(MultipartMixedHTMLExtractor.parseBoundary(from: ct), "abc-123")
+    }
+
+    func testParseBoundaryUnquoted() {
+        let ct = "multipart/mixed; boundary=xyz9"
+        XCTAssertEqual(MultipartMixedHTMLExtractor.parseBoundary(from: ct), "xyz9")
+    }
+
+    func testExtractHTMLPart_skipsJsonThenReturnsHtml() throws {
+        let boundary = "bnd"
+        let raw = [
+            "--\(boundary)",
+            "Type: json",
+            "Bookmark-Id: other",
+            "",
+            "{}",
+            "--\(boundary)",
+            "Type: html",
+            "Bookmark-Id: targetId",
+            "",
+            "<p>hello</p>",
+            "--\(boundary)--",
+            ""
+        ].joined(separator: "\r\n")
+        let html = try MultipartMixedHTMLExtractor.extractHTML(
+            data: Data(raw.utf8),
+            contentTypeValue: "multipart/mixed; boundary=\(boundary)",
+            bookmarkId: "targetId"
+        )
+        XCTAssertEqual(html, "<p>hello</p>")
+    }
+}


### PR DESCRIPTION
Retry the same URL with Accept-Encoding (gzip, deflate, br). If that still returns 502, POST /api/bookmarks/sync for a single id with with_html and extract the Type: html part from multipart/mixed.

Adds MultipartMixedHTMLExtractor and URLProtocol-based unit tests.