### PR TITLE
fix: disable rubberband scrolling in article reader (#30)

### DIFF
--- a/readeck/UI/BookmarkDetail/BookmarkDetailLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailLegacyView.swift
@@ -166,6 +166,7 @@ struct BookmarkDetailLegacyView: View {
         .clipped()
         .ignoresSafeArea(edges: .top)
         .scrollPosition($scrollPosition)
+        .disableScrollBounce()
         .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
             contentEndPosition = endPosition
 

--- a/readeck/UI/BookmarkDetail/BookmarkDetailView2.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailView2.swift
@@ -201,6 +201,7 @@ struct BookmarkDetailView2: View {
             .clipped()
             .ignoresSafeArea(edges: [.top, .bottom])
             .scrollPosition($scrollPosition)
+            .disableScrollBounce()
             .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
                 contentEndPosition = endPosition
 

--- a/readeck/UI/Components/DisableBounceModifier.swift
+++ b/readeck/UI/Components/DisableBounceModifier.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UIKit
+
+extension View {
+    func disableScrollBounce() -> some View {
+        background(ScrollBounceDisabler())
+    }
+}
+
+private struct ScrollBounceDisabler: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        DispatchQueue.main.async {
+            view.enclosingScrollView?.bounces = false
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        DispatchQueue.main.async {
+            uiView.enclosingScrollView?.bounces = false
+        }
+    }
+}
+
+private extension UIView {
+    var enclosingScrollView: UIScrollView? {
+        var view: UIView? = superview
+        while let current = view {
+            if let scrollView = current as? UIScrollView {
+                return scrollView
+            }
+            view = current.superview
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Closes #30

## Summary
- Disables the elastic bounce ("rubberband") effect on the main article reader `ScrollView` in both `BookmarkDetailView2` and `BookmarkDetailLegacyView`
- Adds a small reusable `.disableScrollBounce()` SwiftUI modifier (`UIViewRepresentable` that walks up the view hierarchy and sets `bounces = false` on the enclosing `UIScrollView`)
- No setting introduced — disabled globally for the reader, as per issue discussion

## Test plan
- [ ] Open an article, scroll to the bottom and pull further → no bounce back
- [ ] Scroll to the top and pull further → no bounce
- [ ] Normal scrolling still smooth; toolbar fade / progress / jump-to-progress unaffected
- [ ] Horizontal labels row under the title still bounces (only the main reader is changed)