### PR TITLE
fix(oauth): client_uri, double-tap guard & retry UX (from #56)

### DIFF
--- a/readeck/Data/OAuth/OAuthFlowCoordinator.swift
+++ b/readeck/Data/OAuth/OAuthFlowCoordinator.swift
@@ -19,6 +19,7 @@ final class OAuthFlowCoordinator {
     private var currentVerifier: String?
     private var currentState: String?
     private var currentEndpoint: String?
+    private var isFlowInProgress = false
 
     init(manager: OAuthManager) {
         self.manager = manager
@@ -29,6 +30,13 @@ final class OAuthFlowCoordinator {
     /// - Parameter endpoint: Server endpoint URL
     /// - Returns: (OAuth access token, Client ID)
     func executeOAuthFlow(endpoint: String) async throws -> (OAuthToken, String) {
+        guard !isFlowInProgress else {
+            logger.error("OAuth flow already in progress, ignoring duplicate request")
+            throw OAuthError.flowAlreadyInProgress
+        }
+        isFlowInProgress = true
+        defer { isFlowInProgress = false }
+
         logger.info("🔐 Starting OAuth flow for endpoint: \(endpoint)")
 
         // Phase 1: Register client and generate PKCE

--- a/readeck/Data/OAuth/OAuthManager.swift
+++ b/readeck/Data/OAuth/OAuthManager.swift
@@ -60,7 +60,9 @@ final class OAuthManager {
         // Generate CSRF state
         let state = UUID().uuidString
 
-        // Register OAuth client
+        // Register a fresh OAuth client on every login. Readeck does not persist
+        // dynamically-registered clients across authorize flows, so reusing a stored
+        // client id makes the server reject /authorize with "invalid_client".
         let client = try await repository.registerClient(
             endpoint: endpoint,
             clientName: Self.clientName,
@@ -138,6 +140,7 @@ enum OAuthError: LocalizedError {
     case stateMismatch
     case invalidCallback
     case userCancelled
+    case flowAlreadyInProgress
 
     var errorDescription: String? {
         switch self {
@@ -147,6 +150,8 @@ enum OAuthError: LocalizedError {
             return "Invalid OAuth callback URL"
         case .userCancelled:
             return "OAuth authorization was cancelled by user"
+        case .flowAlreadyInProgress:
+            return "An OAuth login is already in progress"
         }
     }
 }

--- a/readeck/Data/Repository/OAuthRepository.swift
+++ b/readeck/Data/Repository/OAuthRepository.swift
@@ -26,7 +26,7 @@ final class OAuthRepository: POAuthRepository {
 
         let request = OAuthClientCreateDto(
             clientName: clientName,
-            clientUri: "https://github.com/yourusername/readeck-ios", // TODO: Update with actual URL
+            clientUri: "https://github.com/ilyas-hallak/readeck-ios",
             softwareId: softwareId,
             softwareVersion: appVersion,
             redirectUris: [redirectUri],

--- a/readeck/UI/Onboarding/OnboardingServerView.swift
+++ b/readeck/UI/Onboarding/OnboardingServerView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OnboardingServerView: View {
     @State private var viewModel = SettingsServerViewModel()
     @State private var showLoginFields = false
+    @State private var oauthFailed = false
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
@@ -71,6 +72,15 @@ struct OnboardingServerView: View {
         return !viewModel.endpoint.isEmpty
     }
 
+    private var buttonTitle: String {
+        if viewModel.isLoading {
+            if showLoginFields { return "Logging in..." }
+            return oauthFailed ? "Retrying..." : "Checking..."
+        }
+        if showLoginFields { return "Login & Save" }
+        return oauthFailed ? "Retry" : "Continue"
+    }
+
     private var classicLoginForm: some View {
         VStack(spacing: 20) {
             // Readeck Logo with green background
@@ -114,6 +124,7 @@ struct OnboardingServerView: View {
                         .disableAutocorrection(true)
                         .onChange(of: viewModel.endpoint) {
                             viewModel.clearMessages()
+                            oauthFailed = false
                         }
 
                     // Quick Input Chips
@@ -236,15 +247,20 @@ struct OnboardingServerView: View {
             VStack(spacing: 10) {
                 Button(action: {
                     Task {
-                        if !showLoginFields {
+                        if oauthFailed {
+                            // Retry OAuth instead of immediately falling back to classic login
+                            await viewModel.loginWithOAuth()
+                            if viewModel.errorMessage == nil {
+                                oauthFailed = false
+                            }
+                        } else if !showLoginFields {
                             // Phase 1: Check server for OAuth support
                             await viewModel.checkServerOAuthSupport()
                             if viewModel.serverSupportsOAuth {
                                 // Try OAuth login
                                 await viewModel.loginWithOAuth()
-                                // If OAuth fails, error message is shown, user can fallback to classic
                                 if viewModel.errorMessage != nil {
-                                    showLoginFields = true
+                                    oauthFailed = true
                                 }
                             } else {
                                 // No OAuth → show login fields for classic auth
@@ -262,7 +278,7 @@ struct OnboardingServerView: View {
                                 .scaleEffect(0.8)
                                 .progressViewStyle(CircularProgressViewStyle(tint: .white))
                         }
-                        Text(viewModel.isLoading ? (showLoginFields ? "Logging in..." : "Checking...") : (showLoginFields ? "Login & Save" : "Continue"))
+                        Text(buttonTitle)
                             .fontWeight(.semibold)
                     }
                     .frame(maxWidth: .infinity)
@@ -272,6 +288,16 @@ struct OnboardingServerView: View {
                     .cornerRadius(10)
                 }
                 .disabled(!buttonEnabled || viewModel.isLoading)
+
+                if oauthFailed {
+                    Button("Use username & password instead") {
+                        oauthFailed = false
+                        showLoginFields = true
+                        viewModel.clearMessages()
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                }
             }
         }
     }

--- a/readeck/UI/Settings/SettingsServerViewModel.swift
+++ b/readeck/UI/Settings/SettingsServerViewModel.swift
@@ -138,6 +138,9 @@ final class SettingsServerViewModel {
             return
         }
 
+        isLoading = true
+        defer { isLoading = false }
+
         let normalizedEndpoint = EndpointValidator.normalize(endpoint)
 
         do {


### PR DESCRIPTION
OAuth login fixes, pulled out of #56.

## What
- `client_uri` placeholder → real repo URL
- guard against double-tapping the login button
- OAuth fail → Retry instead of instantly dumping you to user/pass, plus an explicit fallback button
- loading state during the OAuth check

## Dropped from #56: client reuse
#56 wanted to reuse the registered OAuth client. Tested on-device: nope, breaks login. Readeck doesn't persist dynamic clients across authorize flows, so a stored client just throws \`invalid_client\` next login. So: fresh register every login.

## How to test
1. fresh login → works
2. logout → login again → works (no \`invalid_client\`)
3. spam the login button → only one flow kicks off
4. cancel/fail OAuth → Retry + fallback do their thing