### PR TITLE
fix(server-info): decode /api/info version defensively (#57, #52)

### DIFF
--- a/URLShare/SimpleAPIDTOs.swift
+++ b/URLShare/SimpleAPIDTOs.swift
@@ -9,6 +9,22 @@ public struct ServerInfoDto: Codable {
         public let canonical: String
         public let release: String?
         public let build: String?
+
+        // Accept both the modern object form and the legacy plain-string form of `version`.
+        public init(from decoder: Decoder) throws {
+            if let single = try? decoder.singleValueContainer(),
+               let versionString = try? single.decode(String.self) {
+                self.canonical = versionString
+                self.release = versionString
+                self.build = nil
+                return
+            }
+
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.canonical = try container.decode(String.self, forKey: .canonical)
+            self.release = try container.decodeIfPresent(String.self, forKey: .release)
+            self.build = try container.decodeIfPresent(String.self, forKey: .build)
+        }
     }
 
     // HTML bookmark submission requires Readeck >= 0.22

--- a/readeck/Data/API/DTOs/ServerInfoDto.swift
+++ b/readeck/Data/API/DTOs/ServerInfoDto.swift
@@ -7,7 +7,28 @@ struct ServerInfoDto: Codable {
 
     struct VersionInfo: Codable {
         let canonical: String
-        let release: String
-        let build: String
+        let release: String?
+        let build: String?
+    }
+}
+
+// Decode `version` defensively: newer Readeck servers return a nested object
+// ({canonical, release, build}), while older ones return a plain version string.
+// release/build are optional because some server versions omit them. This keeps
+// login working across the whole range instead of failing with a decoding error.
+extension ServerInfoDto.VersionInfo {
+    init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let versionString = try? single.decode(String.self) {
+            self.canonical = versionString
+            self.release = versionString
+            self.build = nil
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.canonical = try container.decode(String.self, forKey: .canonical)
+        self.release = try container.decodeIfPresent(String.self, forKey: .release)
+        self.build = try container.decodeIfPresent(String.self, forKey: .build)
     }
 }

--- a/readeckTests/Domain/ServerInfoTests.swift
+++ b/readeckTests/Domain/ServerInfoTests.swift
@@ -211,4 +211,51 @@ struct ServerInfoTests {
         #expect(dto.version.build == "")
         #expect(dto.features == ["oauth"])
     }
+
+    @Test("Decodes real 0.20.1 response without features array")
+    func decode_RealServerResponse_0201_WithoutFeatures() throws {
+        // Actual /api/info from a Readeck 0.20.1 instance — no "features" key at all.
+        let json = #"{"version":{"canonical":"0.20.1","release":"0.20.1","build":""}}"#.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(ServerInfoDto.self, from: json)
+
+        #expect(dto.version.canonical == "0.20.1")
+        #expect(dto.features == nil)
+    }
+
+    @Test("Decodes legacy plain-string version")
+    func decode_LegacyPlainStringVersion() throws {
+        // Older Readeck servers return `version` as a plain string, not an object.
+        let json = #"{"version":"0.15.0"}"#.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(ServerInfoDto.self, from: json)
+
+        #expect(dto.version.canonical == "0.15.0")
+        #expect(dto.version.release == "0.15.0")
+        #expect(dto.version.build == nil)
+        #expect(dto.features == nil)
+    }
+
+    @Test("Decodes version object with missing build/release")
+    func decode_VersionObject_MissingBuildAndRelease() throws {
+        // Some server versions omit build (and/or release) from the version object.
+        let json = #"{"version":{"canonical":"0.19.0"},"features":["oauth"]}"#.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(ServerInfoDto.self, from: json)
+
+        #expect(dto.version.canonical == "0.19.0")
+        #expect(dto.version.release == nil)
+        #expect(dto.version.build == nil)
+        #expect(dto.features == ["oauth"])
+    }
+
+    @Test("Decodes version object with explicit null build")
+    func decode_VersionObject_NullBuild() throws {
+        let json = #"{"version":{"canonical":"0.19.0","release":"0.19.0","build":null}}"#.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(ServerInfoDto.self, from: json)
+
+        #expect(dto.version.canonical == "0.19.0")
+        #expect(dto.version.build == nil)
+    }
 }


### PR DESCRIPTION
Makes `/api/info` decoding survive server-version quirks, so a decode fail can't show up as "response was not in the correct format" and block login.

## What
- `version` now decodes from **both** the object form (`{canonical, release, build}`) and the legacy plain-string form
- `release` / `build` are optional now (some versions just don't send them)
- same fix in the share extension DTO so both targets behave the same
- regression tests: legacy string, missing `build`/`release`, `build: null`, real `0.20.1` response

## How to test
1. login against a normal server → still works
2. point at an old server sending `version` as a plain string → decodes, no "not in correct format"
3. run `ServerInfoTests` → all green