### PR TITLE
fix(server-url): sanitize typed endpoint (smart punctuation / invisible chars) (#57)

### DIFF
--- a/readeck/Domain/Utils/EndpointValidator.swift
+++ b/readeck/Domain/Utils/EndpointValidator.swift
@@ -10,6 +10,8 @@ import Foundation
 /// Validates and normalizes server endpoint URLs for consistent API usage
 struct EndpointValidator {
     /// Normalizes an endpoint URL by:
+    /// - Sanitizing characters iOS may inject while typing (smart-punctuation
+    ///   dashes, non-breaking/zero-width whitespace) that silently corrupt the URL
     /// - Trimming whitespace
     /// - Ensuring proper scheme (http/https, defaults to https if missing)
     /// - Preserving custom ports
@@ -24,8 +26,9 @@ struct EndpointValidator {
     /// - "http://100.80.0.1:8080" → "http://100.80.0.1:8080"
     /// - "https://server:3000/path/" → "https://server:3000/path"
     /// - "192.168.1.100:9090?query=test" → "https://192.168.1.100:9090"
+    /// - "my–server.com" (en dash) → "https://my-server.com"
     static func normalize(_ endpoint: String) -> String {
-        var normalized = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        var normalized = sanitize(endpoint)
 
         // Handle empty input
         guard !normalized.isEmpty else {
@@ -72,6 +75,40 @@ struct EndpointValidator {
     }
 
     // MARK: - Private Helpers
+
+    /// Typographic dashes iOS smart punctuation may substitute for a plain hyphen.
+    private static let typographicDashes: Set<Character> = [
+        "\u{2010}", "\u{2011}", "\u{2012}", "\u{2013}", "\u{2014}", "\u{2015}", "\u{2212}"
+    ]
+
+    /// Zero-width / byte-order-mark scalars that can slip in unseen and break URL parsing.
+    private static let invisibleScalars: Set<Unicode.Scalar> = [
+        "\u{200B}", "\u{200C}", "\u{200D}", "\u{FEFF}"
+    ]
+
+    /// Removes characters that a user never intends in a server URL but iOS may inject
+    /// while typing: smart-punctuation dashes (→ plain hyphen), any whitespace
+    /// (incl. non-breaking spaces), and zero-width/BOM characters. A server endpoint
+    /// contains no interior whitespace, so dropping all of it is safe and also handles
+    /// leading/trailing trimming.
+    private static func sanitize(_ raw: String) -> String {
+        var result = ""
+        result.reserveCapacity(raw.count)
+        for character in raw {
+            if typographicDashes.contains(character) {
+                result.append("-")
+            } else if character.isWhitespace {
+                continue
+            } else if character.unicodeScalars.count == 1,
+                      let scalar = character.unicodeScalars.first,
+                      invisibleScalars.contains(scalar) {
+                continue
+            } else {
+                result.append(character)
+            }
+        }
+        return result
+    }
 
     private static func buildNormalizedURL(from components: URLComponents) -> String {
         var urlComponents = components

--- a/readeckTests/Domain/EndpointValidatorTests.swift
+++ b/readeckTests/Domain/EndpointValidatorTests.swift
@@ -317,6 +317,72 @@ struct EndpointValidatorTests {
         )
     }
 
+    // MARK: - Input Sanitization (iOS smart punctuation / invisible characters)
+
+    @Test("Normalize converts en dash to hyphen")
+    func normalize_EnDashToHyphen() {
+        #expect(
+            EndpointValidator.normalize("https://my\u{2013}server.com") ==
+            "https://my-server.com"
+        )
+    }
+
+    @Test("Normalize converts em dash to hyphen (no scheme)")
+    func normalize_EmDashToHyphen() {
+        #expect(
+            EndpointValidator.normalize("my\u{2014}server.com") ==
+            "https://my-server.com"
+        )
+    }
+
+    @Test("Normalize converts multiple typographic dashes")
+    func normalize_MultipleTypographicDashes() {
+        #expect(
+            EndpointValidator.normalize("https://a\u{2011}b\u{2212}c.example.com") ==
+            "https://a-b-c.example.com"
+        )
+    }
+
+    @Test("Normalize removes non-breaking space")
+    func normalize_RemovesNonBreakingSpace() {
+        #expect(
+            EndpointValidator.normalize("https://example.com\u{00A0}") ==
+            "https://example.com"
+        )
+    }
+
+    @Test("Normalize removes interior non-breaking space")
+    func normalize_RemovesInteriorNonBreakingSpace() {
+        #expect(
+            EndpointValidator.normalize("https://exa\u{00A0}mple.com") ==
+            "https://example.com"
+        )
+    }
+
+    @Test("Normalize removes zero-width space")
+    func normalize_RemovesZeroWidthSpace() {
+        #expect(
+            EndpointValidator.normalize("https://example.com\u{200B}") ==
+            "https://example.com"
+        )
+    }
+
+    @Test("Normalize removes byte-order-mark")
+    func normalize_RemovesBOM() {
+        #expect(
+            EndpointValidator.normalize("\u{FEFF}https://example.com") ==
+            "https://example.com"
+        )
+    }
+
+    @Test("Normalize handles dash and invisible chars together")
+    func normalize_DashAndInvisibleCombined() {
+        #expect(
+            EndpointValidator.normalize("  my\u{2013}server.example.com\u{200B}  ") ==
+            "https://my-server.example.com"
+        )
+    }
+
     // MARK: - Edge Cases
 
     @Test("Normalize empty string")


### PR DESCRIPTION
Fixes #57: the server URL works when pasted but fails ("response was not in the correct format") when typed by hand. Cause is iOS smart punctuation and invisible characters that silently corrupt the URL — en/em dashes replacing hyphens, non-breaking spaces, zero-width chars, BOM.

`EndpointValidator.normalize()` now cleans the input before parsing: typographic dashes → plain hyphen, all whitespace stripped, zero-width/BOM dropped. This is the single choke point every entry path (onboarding + settings) goes through, so no changes to the text fields needed. Covered by 8 new unit test cases.