### PR TITLE
fix: disable rubberband scrolling in reader (#30)

### DIFF
--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -166,6 +166,7 @@ struct ArticleReaderLegacyView: View {
         .clipped()
         .ignoresSafeArea(edges: .top)
         .scrollPosition($scrollPosition)
+        .disableScrollBounce()
         .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
             contentEndPosition = endPosition
 

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -212,6 +212,7 @@ struct ArticleReaderView: View {
             .clipped()
             .ignoresSafeArea(edges: [.top, .bottom])
             .scrollPosition($scrollPosition)
+            .disableScrollBounce()
             .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
                 contentEndPosition = endPosition
 

--- a/readeck/UI/Components/DisableBounceModifier.swift
+++ b/readeck/UI/Components/DisableBounceModifier.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UIKit
+
+extension View {
+    func disableScrollBounce() -> some View {
+        background(ScrollBounceDisabler())
+    }
+}
+
+private struct ScrollBounceDisabler: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        DispatchQueue.main.async {
+            view.enclosingScrollView?.bounces = false
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        DispatchQueue.main.async {
+            uiView.enclosingScrollView?.bounces = false
+        }
+    }
+}
+
+private extension UIView {
+    var enclosingScrollView: UIScrollView? {
+        var view: UIView? = superview
+        while let current = view {
+            if let scrollView = current as? UIScrollView {
+                return scrollView
+            }
+            view = current.superview
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Fixes #30.

Adds a `DisableBounceModifier` and applies it to both readers so the article view no longer bounces/rubberbands past its content while scrolling.