### PR TITLE
fix(reader): recover large articles on gateway errors (#49)

### DIFF
--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -340,10 +340,17 @@ final class API: PAPI {
 
     // MARK: - Bookmark article (GET + 502 recovery)
 
+    /// Gateway/upstream status codes where the origin is likely fine but the proxy failed to relay
+    /// the response. Covers the standard 502/503/504 plus Cloudflare origin codes 520–524
+    /// (524 = proxy timed out waiting for the origin, the typical failure for very large articles).
+    /// All of these are recovered via the streaming sync fallback and are worth retrying.
+    static let recoverableGatewayStatusCodes: Set<Int> = [502, 503, 504, 520, 521, 522, 523, 524]
+
     func getBookmarkArticle(id: String) async throws -> String {
         logger.debug("Fetching article for bookmark: \(id)")
         let endpoint = "/api/bookmarks/\(id)/article"
-        // Proxied instances may return transient 502/503/504 while the origin is slow or busy.
+        // Proxied instances (e.g. Cloudflare) may return transient 502/503/504 or 520–524 while the
+        // origin is slow or busy — common for very large articles that take long to generate.
         let requestTimeout: TimeInterval = 300
         let maxAttempts = 4
 
@@ -354,7 +361,7 @@ final class API: PAPI {
             }
 
             do {
-                let result = try await fetchBookmarkArticleRecoveringFrom502(
+                let result = try await fetchBookmarkArticleRecoveringFromGatewayError(
                     id: id,
                     endpoint: endpoint,
                     timeout: requestTimeout
@@ -367,7 +374,7 @@ final class API: PAPI {
                     if case .serverError(let code) = apiError { return code }
                     return nil
                 }()
-                let isTransientHTTP = apiStatus.map { [502, 503, 504].contains($0) } ?? false
+                let isTransientHTTP = apiStatus.map { Self.recoverableGatewayStatusCodes.contains($0) } ?? false
                 let isTimeout = (error as? URLError)?.code == .timedOut
                 let canRetry = attempt < maxAttempts && (isTransientHTTP || isTimeout)
 
@@ -389,12 +396,12 @@ final class API: PAPI {
         throw APIError.invalidResponse
     }
 
-    private func fetchBookmarkArticleRecoveringFrom502(id: String, endpoint: String, timeout: TimeInterval) async throws -> String {
+    private func fetchBookmarkArticleRecoveringFromGatewayError(id: String, endpoint: String, timeout: TimeInterval) async throws -> String {
         switch try await fetchBookmarkArticleGETOutcome(endpoint: endpoint, timeout: timeout, additionalHeaders: [:]) {
         case let .success(html):
             logger.debug("Bookmark article fetch path: GET /article")
             return html
-        case .badGateway:
+        case .gatewayError:
             break
         case let .httpFailure(statusCode):
             handleUnauthorizedResponse(statusCode)
@@ -407,16 +414,16 @@ final class API: PAPI {
             additionalHeaders: ["Accept-Encoding": "gzip, deflate, br"]
         ) {
         case let .success(html):
-            logger.info("Bookmark article fetch path: GET /article with Accept-Encoding after 502")
+            logger.info("Bookmark article fetch path: GET /article with Accept-Encoding after gateway error")
             return html
-        case .badGateway:
+        case .gatewayError:
             break
         case let .httpFailure(statusCode):
             handleUnauthorizedResponse(statusCode)
             throw APIError.serverError(statusCode)
         }
 
-        logger.info("Bookmark article fetch path: POST /bookmarks/sync multipart fallback")
+        logger.info("Bookmark article fetch path: POST /bookmarks/sync multipart fallback after gateway error")
         return try await fetchBookmarkArticleThroughSync(bookmarkId: id, timeout: timeout)
     }
 
@@ -441,8 +448,8 @@ final class API: PAPI {
             throw APIError.invalidResponse
         }
 
-        if httpResponse.statusCode == 502 {
-            return .badGateway
+        if Self.recoverableGatewayStatusCodes.contains(httpResponse.statusCode) {
+            return .gatewayError(statusCode: httpResponse.statusCode)
         }
 
         guard 200...299 ~= httpResponse.statusCode else {

--- a/readeck/Data/API/BookmarkArticleGETOutcome.swift
+++ b/readeck/Data/API/BookmarkArticleGETOutcome.swift
@@ -5,6 +5,8 @@
 
 enum BookmarkArticleGETOutcome {
     case success(String)
-    case badGateway
+    /// Gateway/upstream error where the origin is likely reachable but the proxy failed to
+    /// relay a large or slow article response. Recoverable via the streaming sync fallback.
+    case gatewayError(statusCode: Int)
     case httpFailure(statusCode: Int)
 }

--- a/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
+++ b/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
@@ -146,6 +146,91 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
         XCTAssertEqual(html, "<article>x</article>")
     }
 
+    func testGetBookmarkArticle_cloudflare524_thenSyncMultipartReturnsHTML() async throws {
+        // 524 = Cloudflare timed out waiting for the origin — the typical failure for very large
+        // articles (#49). Both GET attempts hit 524; recovery must fall through to /sync.
+        let boundary = "sep524"
+        let multipartBody = [
+            "--\(boundary)",
+            "Type: html",
+            "Bookmark-Id: bm1",
+            "",
+            "<article>long</article>",
+            "--\(boundary)--",
+            ""
+        ].joined(separator: "\r\n")
+
+        ArticleRecoveryURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/article") {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 524,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (response, Data())
+            }
+            if path.hasSuffix("/sync") {
+                XCTAssertEqual(request.httpMethod, "POST")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+                )!
+                return (response, Data(multipartBody.utf8))
+            }
+            XCTFail("Unexpected path: \(path)")
+            throw URLError(.badURL)
+        }
+
+        let api = API(tokenProvider: TestMockTokenProvider())
+        let html = try await api.getBookmarkArticle(id: "bm1")
+        XCTAssertEqual(html, "<article>long</article>")
+    }
+
+    func testGetBookmarkArticle_503_recoversViaSync() async throws {
+        let boundary = "sep503"
+        let multipartBody = [
+            "--\(boundary)",
+            "Type: html",
+            "Bookmark-Id: bm1",
+            "",
+            "<article>y</article>",
+            "--\(boundary)--",
+            ""
+        ].joined(separator: "\r\n")
+
+        ArticleRecoveryURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("/article") {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 503,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (response, Data())
+            }
+            if path.hasSuffix("/sync") {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "multipart/mixed; boundary=\(boundary)"]
+                )!
+                return (response, Data(multipartBody.utf8))
+            }
+            XCTFail("Unexpected path: \(path)")
+            throw URLError(.badURL)
+        }
+
+        let api = API(tokenProvider: TestMockTokenProvider())
+        let html = try await api.getBookmarkArticle(id: "bm1")
+        XCTAssertEqual(html, "<article>y</article>")
+    }
+
     func testGetBookmarkArticle_allPathsFail_throws502() async throws {
         ArticleRecoveryURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(


### PR DESCRIPTION
Fixes #49.

Very large articles fail to load when the server sits behind a proxy (e.g. Cloudflare) that returns a gateway error while the origin is slowly generating the response. The recovery chain previously only fell through to the streaming sync fallback on a bare **502** — so Cloudflare's own origin codes (**520–524**, especially **524 = proxy timeout**) threw immediately instead of recovering.

- Central set `recoverableGatewayStatusCodes = [502, 503, 504, 520–524]`
- Recovery chain and the outer retry loop both use it, so large articles reliably fall through to `POST /api/bookmarks/sync`
- 2 new unit tests (524 → sync, 503 → sync)

Note: this fixes the *loading* path (the Cloudflare 50x issue confirmed by @grabowskil). If very large HTML additionally hits a WebView render limit, that would be a separate follow-up.