### PR TITLE
test: fix loadBookmarksFailure to match error message format

### DIFF
--- a/readeckTests/ViewModels/BookmarksViewModelTests.swift
+++ b/readeckTests/ViewModels/BookmarksViewModelTests.swift
@@ -59,7 +59,7 @@ struct BookmarksViewModelTests {
 
         await vm.loadBookmarks()
 
-        #expect(vm.errorMessage == "Error loading bookmarks")
+        #expect(vm.errorMessage?.hasPrefix("Error loading bookmarks") == true)
         #expect(vm.isLoading == false)
     }
 


### PR DESCRIPTION
`BookmarksViewModel` appends `error.localizedDescription` to the message, so the test's exact-equality assertion had been red since it was added. Assert on the prefix instead.

Mirrors Codeberg PR #42 (thanks @sibson).