### PR TITLE
fix(bookmarks): preserve type/tag filter when reloading after mutations (#39)

### DIFF
--- a/readeck/UI/Bookmarks/BookmarksViewModel.swift
+++ b/readeck/UI/Bookmarks/BookmarksViewModel.swift
@@ -123,7 +123,7 @@ final class BookmarksViewModel {
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             Task {
-                await self.loadBookmarks(state: self.currentState)
+                await self.loadBookmarks(state: self.currentState, type: self.currentType, tag: self.currentTag)
             }
         }
 
@@ -263,7 +263,7 @@ final class BookmarksViewModel {
 
     @MainActor
     func refreshBookmarks() async {
-        await loadBookmarks(state: currentState)
+        await loadBookmarks(state: currentState, type: currentType, tag: currentTag)
     }
 
     @MainActor
@@ -293,7 +293,7 @@ final class BookmarksViewModel {
                 isArchived: !bookmark.isArchived
             )
 
-            await loadBookmarks(state: currentState)
+            await loadBookmarks(state: currentState, type: currentType, tag: currentTag)
         } catch {
             errorMessage = "Error archiving bookmark"
         }
@@ -307,7 +307,7 @@ final class BookmarksViewModel {
                 isMarked: !bookmark.isMarked
             )
 
-            await loadBookmarks(state: currentState)
+            await loadBookmarks(state: currentState, type: currentType, tag: currentTag)
         } catch {
             errorMessage = "Error marking bookmark"
         }
@@ -340,7 +340,7 @@ final class BookmarksViewModel {
                 anchor: nil
             )
 
-            await loadBookmarks(state: currentState)
+            await loadBookmarks(state: currentState, type: currentType, tag: currentTag)
         } catch {
             errorMessage = "Error resetting reading progress"
         }

--- a/readeckTests/Helpers/ConfigurableMocks.swift
+++ b/readeckTests/Helpers/ConfigurableMocks.swift
@@ -10,11 +10,16 @@ class ConfigurableGetBookmarksUseCase: PGetBookmarksUseCase {
     )
     var executeCalled = false
     var lastState: BookmarkState?
+    // swiftlint:disable:next discouraged_optional_collection
+    var lastType: [BookmarkType]?
+    var lastTag: String?
 
     // swiftlint:disable:next discouraged_optional_collection
     func execute(state: BookmarkState?, limit: Int?, offset: Int?, search: String?, type: [BookmarkType]?, tag: String?, sort: String?) async throws -> BookmarksPage {
         executeCalled = true
         lastState = state
+        lastType = type
+        lastTag = tag
         return try result.get()
     }
 }

--- a/readeckTests/ViewModels/BookmarksViewModelTests.swift
+++ b/readeckTests/ViewModels/BookmarksViewModelTests.swift
@@ -83,6 +83,22 @@ struct BookmarksViewModelTests {
         #expect(factory.mockUpdateBookmark.toggleArchiveCalled == true)
     }
 
+    @Test("Archiving preserves the active type filter (regression: Codeberg #39)")
+    func toggleArchivePreservesTypeFilter() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .success(
+            BookmarksPage(bookmarks: [.mock], currentPage: 1, totalCount: 1, totalPages: 1, links: nil)
+        )
+        // Load the Unread tab showing all types (articles, videos, photos).
+        await vm.loadBookmarks(state: .unread, type: [.article, .video, .photo])
+
+        await vm.toggleArchive(bookmark: .mock)
+
+        // The reload after archiving must keep the active filter instead of falling back to
+        // [.article]; otherwise videos/photos vanish from the list until the tab is switched.
+        #expect(factory.mockGetBookmarks.lastType == [.article, .video, .photo])
+    }
+
     // MARK: - Toggle Favorite
 
     @Test("Toggle favorite calls update use case")


### PR DESCRIPTION
Fixes Codeberg #39 — archiving an unread article made other types (YouTube/PeerTube **videos**, photos) vanish from the Unread list until switching tabs.

**Cause**
`loadBookmarks(...)` defaults `type` to `[.article]`. Five "reload current view" paths (`toggleArchive`, `toggleFavorite`, `resetReadProgress`, `refreshBookmarks`, search debounce) called it without `type`/`tag`, so after the mutation only articles were reloaded and everything else was filtered out. Switching tabs reloaded with the correct type, which is why the items "came back".

**Fix**
Pass `currentType`/`currentTag` on all reload paths — consistent with the already-correct `retryLoading`. Adds a regression test (`toggleArchivePreservesTypeFilter`) asserting the active filter survives an archive.

**Note**
The pre-existing `loadBookmarksFailure` test failure on this branch is unrelated — it's the Codeberg #42 issue fixed separately in PR #65; it goes green once #65 lands in main.