### PR TITLE
feat(reader): choose after-archive behaviour - next article / return to list (#55)

### DIFF
--- a/readeck.xcodeproj/project.pbxproj
+++ b/readeck.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 				Data/API/DTOs/OAuthTokenResponseDto.swift,
 				Data/CoreData/CoreDataManager.swift,
 				"Data/Extensions/NSManagedObjectContext+SafeFetch.swift",
+				"Data/Extensions/String+Localization.swift",
 				Data/KeychainHelper.swift,
 				Data/Utils/HTTPHeadersHelper.swift,
 				Data/Utils/LabelUtils.swift,

--- a/readeck.xcodeproj/project.pbxproj
+++ b/readeck.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 				Data/KeychainHelper.swift,
 				Data/Utils/HTTPHeadersHelper.swift,
 				Data/Utils/LabelUtils.swift,
+				Domain/Model/ArchiveAdvanceMode.swift,
 				Domain/Model/Bookmark.swift,
 				Domain/Model/BookmarkLabel.swift,
 				Domain/Model/BookmarkSortSettings.swift,

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -67,6 +67,13 @@ final class SettingsRepository: PSettingsRepository {
                         existingSettings.autoAdvanceAfterArchive = autoAdvanceAfterArchive
                     }
 
+                    if let archiveAdvanceMode = settings.archiveAdvanceMode {
+                        existingSettings.archiveAdvanceMode = archiveAdvanceMode.rawValue
+                        // Keep the legacy boolean in sync so an older app version
+                        // (which only reads it) still behaves sensibly after a downgrade.
+                        existingSettings.autoAdvanceAfterArchive = (archiveAdvanceMode != .stay)
+                    }
+
                     if let theme = settings.theme {
                         existingSettings.theme = theme.rawValue
                     }
@@ -195,6 +202,17 @@ final class SettingsRepository: PSettingsRepository {
                         bookmarkSortDirection: BookmarkSortDirection(rawValue: settingEntity?.bookmarkSortDirection ?? BookmarkSortDirection.descending.rawValue),
                         disableReaderBackSwipe: settingEntity?.disableReaderBackSwipe,
                         autoAdvanceAfterArchive: settingEntity?.autoAdvanceAfterArchive,
+                        archiveAdvanceMode: {
+                            if let raw = settingEntity?.archiveAdvanceMode,
+                               let mode = ArchiveAdvanceMode(rawValue: raw) {
+                                return mode
+                            }
+                            // Migrate from the legacy boolean: true → advance, false → stay.
+                            if let legacy = settingEntity?.autoAdvanceAfterArchive {
+                                return legacy ? .nextArticle : .stay
+                            }
+                            return nil
+                        }(),
                         urlOpener: UrlOpener(rawValue: settingEntity?.urlOpener ?? UrlOpener.inAppBrowser.rawValue),
                         swipeActionConfig: swipeActionConfig,
                         fontSizeNumeric: fontSizeNumeric,

--- a/readeck/Domain/Model/ArchiveAdvanceMode.swift
+++ b/readeck/Domain/Model/ArchiveAdvanceMode.swift
@@ -1,0 +1,33 @@
+//
+//  ArchiveAdvanceMode.swift
+//  readeck
+//
+//  What should happen to the reader after the currently-open article is
+//  archived (or deleted). Replaces the former boolean auto-advance toggle so
+//  users can choose between advancing to the next article (#55) and returning
+//  to the list (Codeberg #41).
+//
+
+import Foundation
+
+enum ArchiveAdvanceMode: String, CaseIterable, Identifiable {
+    /// Stay on the current article — do nothing (previously: toggle off).
+    case stay
+    /// Open the next article in the list (previously: toggle on). Covers #55.
+    case nextArticle
+    /// Dismiss the reader and return to the list. Covers Codeberg #41.
+    case returnToList
+
+    var id: String { rawValue }
+
+    var localizedTitle: String {
+        switch self {
+        case .stay:
+            return NSLocalizedString("Stay on Article", comment: "Archive-advance mode")
+        case .nextArticle:
+            return NSLocalizedString("Open Next Article", comment: "Archive-advance mode")
+        case .returnToList:
+            return NSLocalizedString("Return to List", comment: "Archive-advance mode")
+        }
+    }
+}

--- a/readeck/Domain/Model/ArchiveAdvanceMode.swift
+++ b/readeck/Domain/Model/ArchiveAdvanceMode.swift
@@ -23,11 +23,11 @@ enum ArchiveAdvanceMode: String, CaseIterable, Identifiable {
     var localizedTitle: String {
         switch self {
         case .stay:
-            return NSLocalizedString("Stay on Article", comment: "Archive-advance mode")
+            return "Stay on Article".localized
         case .nextArticle:
-            return NSLocalizedString("Open Next Article", comment: "Archive-advance mode")
+            return "Open Next Article".localized
         case .returnToList:
-            return NSLocalizedString("Return to List", comment: "Archive-advance mode")
+            return "Return to List".localized
         }
     }
 }

--- a/readeck/Domain/Model/Settings.swift
+++ b/readeck/Domain/Model/Settings.swift
@@ -24,8 +24,10 @@ struct Settings {
     var bookmarkSortDirection: BookmarkSortDirection?
 
     var disableReaderBackSwipe: Bool?
+    // Legacy boolean, kept for migration into `archiveAdvanceMode`.
     // swiftlint:disable:next discouraged_optional_boolean
     var autoAdvanceAfterArchive: Bool?
+    var archiveAdvanceMode: ArchiveAdvanceMode?
     var urlOpener: UrlOpener?
     var swipeActionConfig: SwipeActionConfig?
 

--- a/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
+++ b/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
@@ -12,7 +12,7 @@ protocol PSaveSettingsUseCase {
     func execute(urlOpener: UrlOpener) async throws
     func execute(bookmarkSortField: BookmarkSortField, bookmarkSortDirection: BookmarkSortDirection) async throws
     func execute(disableReaderBackSwipe: Bool) async throws
-    func execute(autoAdvanceAfterArchive: Bool) async throws
+    func execute(archiveAdvanceMode: ArchiveAdvanceMode) async throws
     func execute(swipeActionConfig: SwipeActionConfig) async throws
 }
 
@@ -110,9 +110,9 @@ final class SaveSettingsUseCase: PSaveSettingsUseCase {
         )
     }
 
-    func execute(autoAdvanceAfterArchive: Bool) async throws {
+    func execute(archiveAdvanceMode: ArchiveAdvanceMode) async throws {
         try await settingsRepository.saveSettings(
-            .init(autoAdvanceAfterArchive: autoAdvanceAfterArchive)
+            .init(archiveAdvanceMode: archiveAdvanceMode)
         )
     }
 

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -278,3 +278,10 @@
 "No article content to summarize." = "Kein Artikelinhalt zum Zusammenfassen vorhanden.";
 "Delete this bookmark?" = "Dieses Lesezeichen löschen?";
 "This action cannot be undone." = "Diese Aktion kann nicht rückgängig gemacht werden.";
+
+// After-archiving behaviour (Reading Settings)
+"After Archiving" = "Nach dem Archivieren";
+"Stay on Article" = "Beim Artikel bleiben";
+"Open Next Article" = "Nächsten Artikel öffnen";
+"Return to List" = "Zurück zur Liste";
+"Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Lege fest, was passiert, wenn du den gerade gelesenen Artikel archivierst oder löschst: beim Artikel bleiben, den nächsten in deiner Liste öffnen oder zur Liste zurückkehren.";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -270,3 +270,10 @@
 "No article content to summarize." = "No article content to summarize.";
 "Delete this bookmark?" = "Delete this bookmark?";
 "This action cannot be undone." = "This action cannot be undone.";
+
+// After-archiving behaviour (Reading Settings)
+"After Archiving" = "After Archiving";
+"Stay on Article" = "Stay on Article";
+"Open Next Article" = "Open Next Article";
+"Return to List" = "Return to List";
+"Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list.";

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -472,7 +472,11 @@ struct ArticleReaderLegacyView: View {
                 Task {
                     let success = await viewModel.deleteBookmark(id: bookmarkId)
                     if success {
-                        dismiss()
+                        // In "next article" mode the bookmarks list drives navigation
+                        // to the following item; dismissing here would pop to the list.
+                        if appSettings.archiveAdvanceMode != .nextArticle {
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -72,7 +72,11 @@ struct ArticleReaderView: View {
                     Task {
                         let success = await viewModel.deleteBookmark(id: bookmarkId)
                         if success {
-                            dismiss()
+                            // In "next article" mode the bookmarks list drives navigation
+                            // to the following item; dismissing here would pop to the list.
+                            if appSettings.archiveAdvanceMode != .nextArticle {
+                                dismiss()
+                            }
                         }
                     }
                 }

--- a/readeck/UI/Bookmarks/BookmarksView.swift
+++ b/readeck/UI/Bookmarks/BookmarksView.swift
@@ -36,12 +36,17 @@ struct BookmarksView: View {
 
     /// Reacts to the currently-open article being archived or deleted, following
     /// the user's "After Archiving" preference:
-    /// `.stay` does nothing, `.nextArticle` advances the reader to the next item
-    /// in the list, `.returnToList` dismisses the reader.
-    private func handleReaderMutation(of mutatedId: String) {
+    /// `.stay` keeps the article open, `.nextArticle` advances the reader to the
+    /// next item in the list, `.returnToList` dismisses the reader.
+    ///
+    /// When the article was *deleted* it no longer exists, so `.stay` and the
+    /// "unknown position" case fall back to closing the reader instead of sitting
+    /// on a gone article. For `.nextArticle` deletions the reader defers its own
+    /// dismissal to us, so this is the sole driver of the post-delete navigation.
+    private func handleReaderMutation(of mutatedId: String, wasDeleted: Bool) {
         switch appSettings.archiveAdvanceMode {
         case .stay:
-            return
+            if wasDeleted { clearReaderSelection() }
         case .returnToList:
             clearReaderSelection()
         case .nextArticle:
@@ -57,7 +62,8 @@ struct BookmarksView: View {
                 // Last article — dismiss the reader / clear the detail column.
                 clearReaderSelection()
             case .noop:
-                break
+                // Position unknown (e.g. not in the current list): only close on delete.
+                if wasDeleted { clearReaderSelection() }
             }
         }
     }
@@ -127,12 +133,12 @@ struct BookmarksView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .bookmarkArchived)) { notification in
             if let id = notification.userInfo?["id"] as? String {
-                handleReaderMutation(of: id)
+                handleReaderMutation(of: id, wasDeleted: false)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .bookmarkDeleted)) { notification in
             if let id = notification.userInfo?["id"] as? String {
-                handleReaderMutation(of: id)
+                handleReaderMutation(of: id, wasDeleted: true)
             }
         }
         .onChange(of: viewModel.showTagsBookmark) { oldValue, newValue in

--- a/readeck/UI/Bookmarks/BookmarksView.swift
+++ b/readeck/UI/Bookmarks/BookmarksView.swift
@@ -32,6 +32,44 @@ struct BookmarksView: View {
         self.tag = tag
     }
 
+    // MARK: After-archive / after-delete behaviour
+
+    /// Reacts to the currently-open article being archived or deleted, following
+    /// the user's "After Archiving" preference:
+    /// `.stay` does nothing, `.nextArticle` advances the reader to the next item
+    /// in the list, `.returnToList` dismisses the reader.
+    private func handleReaderMutation(of mutatedId: String) {
+        switch appSettings.archiveAdvanceMode {
+        case .stay:
+            return
+        case .returnToList:
+            clearReaderSelection()
+        case .nextArticle:
+            let ids = viewModel.bookmarks?.bookmarks.map(\.id) ?? []
+            switch nextSelection(after: mutatedId, in: ids) {
+            case .next(let nextId):
+                if UIDevice.isPhone {
+                    selectedBookmarkId = nextId
+                } else {
+                    selectedBookmark = viewModel.bookmarks?.bookmarks.first { $0.id == nextId }
+                }
+            case .clear:
+                // Last article — dismiss the reader / clear the detail column.
+                clearReaderSelection()
+            case .noop:
+                break
+            }
+        }
+    }
+
+    private func clearReaderSelection() {
+        if UIDevice.isPhone {
+            selectedBookmarkId = nil
+        } else {
+            selectedBookmark = nil
+        }
+    }
+
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
@@ -88,30 +126,13 @@ struct BookmarksView: View {
             await viewModel.loadBookmarks(state: state, type: type, tag: tag)
         }
         .onReceive(NotificationCenter.default.publisher(for: .bookmarkArchived)) { notification in
-            // Auto-advance to the next article after archiving the one being read.
-            // Opt-in via setting; the list + selection both live here, so no state
-            // needs to be threaded down into the reader.
-            guard appSettings.autoAdvanceAfterArchive,
-                  let archivedId = notification.userInfo?["id"] as? String else {
-                return
+            if let id = notification.userInfo?["id"] as? String {
+                handleReaderMutation(of: id)
             }
-            let ids = viewModel.bookmarks?.bookmarks.map(\.id) ?? []
-            switch nextSelection(after: archivedId, in: ids) {
-            case .next(let nextId):
-                if UIDevice.isPhone {
-                    selectedBookmarkId = nextId
-                } else {
-                    selectedBookmark = viewModel.bookmarks?.bookmarks.first { $0.id == nextId }
-                }
-            case .clear:
-                // Last article — dismiss the reader / clear the detail column.
-                if UIDevice.isPhone {
-                    selectedBookmarkId = nil
-                } else {
-                    selectedBookmark = nil
-                }
-            case .noop:
-                break
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .bookmarkDeleted)) { notification in
+            if let id = notification.userInfo?["id"] as? String {
+                handleReaderMutation(of: id)
             }
         }
         .onChange(of: viewModel.showTagsBookmark) { oldValue, newValue in

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -239,7 +239,7 @@ final class MockSaveSettingsUseCase: PSaveSettingsUseCase {
     func execute(urlOpener: UrlOpener) async throws {}
     func execute(bookmarkSortField: BookmarkSortField, bookmarkSortDirection: BookmarkSortDirection) async throws {}
     func execute(disableReaderBackSwipe: Bool) async throws {}
-    func execute(autoAdvanceAfterArchive: Bool) async throws {}
+    func execute(archiveAdvanceMode: ArchiveAdvanceMode) async throws {}
     func execute(swipeActionConfig: SwipeActionConfig) async throws {}
 }
 

--- a/readeck/UI/Models/AppSettings.swift
+++ b/readeck/UI/Models/AppSettings.swift
@@ -28,8 +28,12 @@ final class AppSettings: ObservableObject {
         settings?.disableReaderBackSwipe ?? false
     }
 
-    var autoAdvanceAfterArchive: Bool {
-        settings?.autoAdvanceAfterArchive ?? true
+    var archiveAdvanceMode: ArchiveAdvanceMode {
+        if let mode = settings?.archiveAdvanceMode {
+            return mode
+        }
+        // Migration fallback for settings loaded before this field existed.
+        return settings?.autoAdvanceAfterArchive == false ? .stay : .nextArticle
     }
 
     var theme: Theme {

--- a/readeck/UI/Settings/ReadingSettingsView.swift
+++ b/readeck/UI/Settings/ReadingSettingsView.swift
@@ -58,15 +58,19 @@ struct ReadingSettingsView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Auto-Advance After Archiving", isOn: $viewModel.autoAdvanceAfterArchive)
-                        .onChange(of: viewModel.autoAdvanceAfterArchive) {
-                            guard !viewModel.isLoading else { return }
-                            Task {
-                                await viewModel.saveGeneralSettings()
-                            }
+                    Picker("After Archiving", selection: $viewModel.archiveAdvanceMode) {
+                        ForEach(ArchiveAdvanceMode.allCases) { mode in
+                            Text(mode.localizedTitle).tag(mode)
                         }
+                    }
+                    .onChange(of: viewModel.archiveAdvanceMode) {
+                        guard !viewModel.isLoading else { return }
+                        Task {
+                            await viewModel.saveGeneralSettings()
+                        }
+                    }
 
-                    Text("Automatically opens the next article in your list after you archive the one you're reading.")
+                    Text("Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list.")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .padding(.top, 2)

--- a/readeck/UI/Settings/SettingsGeneralViewModel.swift
+++ b/readeck/UI/Settings/SettingsGeneralViewModel.swift
@@ -16,7 +16,7 @@ final class SettingsGeneralViewModel {
     var enableReaderMode = false
     var enableTTS = false
     var disableReaderBackSwipe = false
-    var autoAdvanceAfterArchive = true
+    var archiveAdvanceMode: ArchiveAdvanceMode = .nextArticle
     var isLoading = false
     var autoMarkAsRead = false
     var urlOpener: UrlOpener = .inAppBrowser
@@ -46,7 +46,8 @@ final class SettingsGeneralViewModel {
             if let settings = try await loadSettingsUseCase.execute() {
                 enableTTS = settings.enableTTS ?? false
                 disableReaderBackSwipe = settings.disableReaderBackSwipe ?? false
-                autoAdvanceAfterArchive = settings.autoAdvanceAfterArchive ?? true
+                archiveAdvanceMode = settings.archiveAdvanceMode
+                    ?? (settings.autoAdvanceAfterArchive == false ? .stay : .nextArticle)
                 selectedTheme = settings.theme ?? .system
                 urlOpener = settings.urlOpener ?? .inAppBrowser
                 bookmarkSortField = settings.bookmarkSortField ?? .created
@@ -63,7 +64,7 @@ final class SettingsGeneralViewModel {
         do {
             try await saveSettingsUseCase.execute(enableTTS: enableTTS)
             try await saveSettingsUseCase.execute(disableReaderBackSwipe: disableReaderBackSwipe)
-            try await saveSettingsUseCase.execute(autoAdvanceAfterArchive: autoAdvanceAfterArchive)
+            try await saveSettingsUseCase.execute(archiveAdvanceMode: archiveAdvanceMode)
             try await saveSettingsUseCase.execute(theme: selectedTheme)
             try await saveSettingsUseCase.execute(urlOpener: urlOpener)
 

--- a/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
+++ b/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
@@ -58,6 +58,7 @@
         <attribute name="src" optional="YES" attributeType="String"/>
     </entity>
     <entity name="SettingEntity" representedClassName="SettingEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="archiveAdvanceMode" optional="YES" attributeType="String"/>
         <attribute name="autoAdvanceAfterArchive" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="bookmarkSortDirection" optional="YES" attributeType="String"/>
         <attribute name="bookmarkSortField" optional="YES" attributeType="String"/>

--- a/readeckTests/Settings/ArchiveAdvanceModeTests.swift
+++ b/readeckTests/Settings/ArchiveAdvanceModeTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import readeck
+
+@Suite("ArchiveAdvanceMode migration")
+struct ArchiveAdvanceModeTests {
+
+    @Test("No settings falls back to advancing to the next article")
+    func defaultWhenNoSettings() {
+        #expect(AppSettings(settings: nil).archiveAdvanceMode == .nextArticle)
+    }
+
+    @Test("Legacy auto-advance ON migrates to next article")
+    func legacyTrueMigratesToNext() {
+        let settings = Settings(autoAdvanceAfterArchive: true)
+        #expect(AppSettings(settings: settings).archiveAdvanceMode == .nextArticle)
+    }
+
+    @Test("Legacy auto-advance OFF migrates to stay")
+    func legacyFalseMigratesToStay() {
+        let settings = Settings(autoAdvanceAfterArchive: false)
+        #expect(AppSettings(settings: settings).archiveAdvanceMode == .stay)
+    }
+
+    @Test("Explicit mode wins over the legacy boolean")
+    func explicitModeWins() {
+        let settings = Settings(autoAdvanceAfterArchive: true, archiveAdvanceMode: .returnToList)
+        #expect(AppSettings(settings: settings).archiveAdvanceMode == .returnToList)
+    }
+}


### PR DESCRIPTION
Replaces the on/off "Auto-Advance After Archiving" toggle with a three-way **After Archiving** picker in Reading Settings:

- **Stay on Article** – do nothing (previous "off").
- **Open Next Article** – advance the reader to the next item (previous "on", covers #55).
- **Return to List** – dismiss the reader and go back to the list (covers Codeberg #41).

The behaviour now also fires on **delete**, not just archive, so #55's "next after deleting" is covered too.

### Notes
- Existing users are migrated automatically: the old `autoAdvanceAfterArchive` boolean maps to *Open Next Article* (true) / *Stay* (false). The legacy boolean is kept in sync on save so a downgrade still behaves sensibly.
- New `ArchiveAdvanceMode` enum + Core Data string attribute; added to the URLShare target membership since it compiles the shared `Settings`/`AppSettings`.
- German + English strings added; migration covered by a unit test (`ArchiveAdvanceModeTests`, 4/4 green).

Closes #55. Addresses Codeberg #41.
