### PR TITLE
Share Extension: "Open in Readeck" button after saving

### DIFF
--- a/URLShare/ShareBookmarkView.swift
+++ b/URLShare/ShareBookmarkView.swift
@@ -51,7 +51,11 @@ struct ShareBookmarkView: View {
                     }
                 }
 
-                saveButtonSection
+                if viewModel.savedBookmarkId != nil {
+                    openInAppButtonSection
+                } else {
+                    saveButtonSection
+                }
             }
         }
         .background(Color(.systemGroupedBackground))
@@ -256,6 +260,22 @@ struct ShareBookmarkView: View {
         .padding(.top, 16)
         .padding(.bottom, 32)
         .disabled(viewModel.isSaving)
+    }
+
+    @ViewBuilder
+    private var openInAppButtonSection: some View {
+        Button(action: { viewModel.openInApp() }) {
+            Label("Open in Readeck", systemImage: "arrow.up.forward.app")
+                .font(.system(size: 17, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.accentColor)
+                .foregroundColor(.white)
+                .cornerRadius(16)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 32)
     }
 
     // MARK: - Helper Functions

--- a/URLShare/ShareBookmarkViewModel.swift
+++ b/URLShare/ShareBookmarkViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 import CoreData
 
@@ -21,6 +22,9 @@ final class ShareBookmarkViewModel: ObservableObject {
     @Published var savedBookmarkId: String?
     let tagSortOrder: TagSortOrder
     let extensionContext: NSExtensionContext?
+    /// A view from the hosting controller, used as the entry point into the responder
+    /// chain when opening the host app (see `openInApp`). Set by `ShareViewController`.
+    weak var hostResponder: UIResponder?
 
     private let logger = Logger.viewModel
     private let serverCheck = ShareExtensionServerCheck.shared
@@ -261,12 +265,43 @@ final class ShareBookmarkViewModel: ObservableObject {
         }
         autoCloseTask?.cancel()
         logger.info("Opening saved bookmark in app: \(url.absoluteString)")
+
+        // `extensionContext.open` is unreliable from a share extension, so we walk the
+        // responder chain to reach the host `UIApplication` and open the URL there. If
+        // no application is found, fall back to `extensionContext.open`.
+        if openViaResponderChain(url) {
+            logger.info("Opened host app via responder chain")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+                self?.completeExtensionRequest()
+            }
+            return
+        }
+
+        logger.info("Responder chain could not open the URL, falling back to extensionContext.open")
         extensionContext?.open(url) { [weak self] success in
             self?.logger.info("extensionContext.open returned success: \(success)")
             DispatchQueue.main.async {
                 self?.completeExtensionRequest()
             }
         }
+    }
+
+    /// Walks up the responder chain from the hosting view to the host `UIApplication`
+    /// and asks it to open the URL. The `as? UIApplication` cast matches only the real
+    /// application, so SwiftUI's hosting view (which also handles `openURL:` via the
+    /// OpenURLAction and would otherwise swallow the call) is skipped. We use the
+    /// non-deprecated `open(_:options:completionHandler:)` — on iOS 18 the old
+    /// `openURL:` is forced to no-op.
+    private func openViaResponderChain(_ url: URL) -> Bool {
+        var responder: UIResponder? = hostResponder
+        while let current = responder {
+            if let application = current as? UIApplication {
+                application.open(url, options: [:], completionHandler: nil)
+                return true
+            }
+            responder = current.next
+        }
+        return false
     }
 
     /// Auto-closes the extension after the given delay unless cancelled (e.g. the user

--- a/URLShare/ShareBookmarkViewModel.swift
+++ b/URLShare/ShareBookmarkViewModel.swift
@@ -15,6 +15,10 @@ final class ShareBookmarkViewModel: ObservableObject {
     @Published var sessionExpired = false
     @Published var pageHTML: String?
     @Published var includeHTML = false
+    /// Set once the bookmark is saved online and the server returned its id. Drives
+    /// the "Open in Readeck" button; nil after a local save or an older server that
+    /// doesn't return the id.
+    @Published var savedBookmarkId: String?
     let tagSortOrder: TagSortOrder
     let extensionContext: NSExtensionContext?
 
@@ -22,6 +26,7 @@ final class ShareBookmarkViewModel: ObservableObject {
     private let serverCheck = ShareExtensionServerCheck.shared
     private let tagRepository = TagRepository()
     private var notificationObserver: Any?
+    private var autoCloseTask: Task<Void, Never>?
 
     init(extensionContext: NSExtensionContext?) {
         self.extensionContext = extensionContext
@@ -124,21 +129,23 @@ final class ShareBookmarkViewModel: ObservableObject {
                 if includeHTML && !serverInfo.supportsHTMLBookmarks {
                     logger.info("Server version \(serverInfo.version.canonical) does not support HTML bookmarks (requires >= 0.22), sending without HTML")
                 }
-                await SimpleAPI.addBookmark(title: title, url: url, labels: Array(selectedLabels), html: htmlToSend) { [weak self] message, error in
-                    self?.logger.info("API save completed - Success: \(!error), Message: \(message)")
-                    if !error && self?.includeHTML == true {
-                        self?.statusMessage = ("Saved with page content", false, "✅")
+                await SimpleAPI.addBookmark(title: title, url: url, labels: Array(selectedLabels), html: htmlToSend) { [weak self] message, error, bookmarkId in
+                    guard let self else { return }
+                    self.logger.info("API save completed - Success: \(!error), Message: \(message), id: \(bookmarkId ?? "unknown")")
+                    if !error && self.includeHTML == true {
+                        self.statusMessage = ("Saved with page content", false, "✅")
                     } else {
-                        self?.statusMessage = (message, error, error ? "❌" : "✅")
+                        self.statusMessage = (message, error, error ? "❌" : "✅")
                     }
-                    self?.isSaving = false
+                    self.isSaving = false
                     if !error {
-                        self?.logger.debug("Bookmark saved successfully, completing extension request")
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            self?.completeExtensionRequest()
-                        }
+                        self.savedBookmarkId = bookmarkId
+                        self.logger.debug("Bookmark saved successfully, id available: \(bookmarkId != nil)")
+                        // When we have an id we show an "Open in Readeck" button and give
+                        // the user time to tap it before auto-closing; otherwise close quickly.
+                        self.scheduleAutoClose(after: bookmarkId != nil ? 6.0 : 0.5)
                     } else {
-                        self?.logger.error("Failed to save bookmark via API: \(message)")
+                        self.logger.error("Failed to save bookmark via API: \(message)")
                     }
                 }
             } else {
@@ -244,6 +251,37 @@ final class ShareBookmarkViewModel: ObservableObject {
         }
     }
 
+    /// Opens the freshly saved bookmark in the main app via the `readeck://` deep link
+    /// and then closes the extension. Cancels the pending auto-close first.
+    func openInApp() {
+        guard let id = savedBookmarkId,
+              let url = URL(string: "readeck://bookmark/\(id)") else {
+            logger.warning("Open in app requested but no saved bookmark id available")
+            return
+        }
+        autoCloseTask?.cancel()
+        logger.info("Opening saved bookmark in app: \(url.absoluteString)")
+        extensionContext?.open(url) { [weak self] success in
+            self?.logger.info("extensionContext.open returned success: \(success)")
+            DispatchQueue.main.async {
+                self?.completeExtensionRequest()
+            }
+        }
+    }
+
+    /// Auto-closes the extension after the given delay unless cancelled (e.g. the user
+    /// tapped "Open in Readeck" first).
+    private func scheduleAutoClose(after seconds: Double) {
+        autoCloseTask?.cancel()
+        autoCloseTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self?.completeExtensionRequest()
+            }
+        }
+    }
+
     private func completeExtensionRequest() {
         logger.debug("Completing extension request")
         guard let context = extensionContext else {
@@ -261,6 +299,7 @@ final class ShareBookmarkViewModel: ObservableObject {
     }
 
     deinit {
+        autoCloseTask?.cancel()
         NotificationCenter.default.removeObserver(self)
     }
 

--- a/URLShare/ShareViewController.swift
+++ b/URLShare/ShareViewController.swift
@@ -35,6 +35,9 @@ final class ShareViewController: UIViewController {
         hostingController.didMove(toParent: self)
         self.hostingController = hostingController
 
+        // Entry point into the responder chain so the view model can open the host app.
+        viewModel.hostResponder = hostingController.view
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(dismissKeyboard),

--- a/URLShare/SimpleAPI.swift
+++ b/URLShare/SimpleAPI.swift
@@ -121,24 +121,27 @@ final class SimpleAPI {
     }
 
     // MARK: - API Methods
+    // The `showStatus` closure reports (message, isError, savedBookmarkId). The id is
+    // read from the `Bookmark-Id` response header on success and is nil on failure —
+    // it lets the extension offer an "Open in Readeck" deep link.
     // swiftlint:disable:next discouraged_optional_collection
-    static func addBookmark(title: String, url: String, labels: [String]? = nil, html: String? = nil, showStatus: @escaping (String, Bool) -> Void) async {
+    static func addBookmark(title: String, url: String, labels: [String]? = nil, html: String? = nil, showStatus: @escaping (String, Bool, String?) -> Void) async {
         logger.info("Adding bookmark: \(url)")
         guard let token = await getValidToken() else {
-            showStatus("No token found. Please log in via the main app.", true)
+            showStatus("No token found. Please log in via the main app.", true, nil)
             return
         }
         guard let endpoint = KeychainHelper.shared.loadEndpoint(), !endpoint.isEmpty else {
-            showStatus("No server endpoint found.", true)
+            showStatus("No server endpoint found.", true, nil)
             return
         }
         let requestDto = CreateBookmarkRequestDto(url: url, title: title, labels: labels, html: html)
         guard let requestData = try? JSONEncoder().encode(requestDto) else {
-            showStatus("Failed to encode request.", true)
+            showStatus("Failed to encode request.", true, nil)
             return
         }
         guard let apiUrl = URL(string: endpoint + "/api/bookmarks") else {
-            showStatus("Invalid server endpoint.", true)
+            showStatus("Invalid server endpoint.", true, nil)
             return
         }
         var request = URLRequest(url: apiUrl)
@@ -151,7 +154,7 @@ final class SimpleAPI {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.error("Invalid server response for bookmark creation")
-                showStatus("Invalid server response.", true)
+                showStatus("Invalid server response.", true, nil)
                 return
             }
 
@@ -163,26 +166,42 @@ final class SimpleAPI {
                         NotificationCenter.default.post(name: .unauthorizedAPIResponse, object: nil)
                     }
                     logger.error("Authentication failed: 401 Unauthorized")
-                    showStatus("Session expired. Please log in via the Readeck app.", true)
+                    showStatus("Session expired. Please log in via the Readeck app.", true, nil)
                     return
                 }
                 let msg = String(data: data, encoding: .utf8) ?? "Unknown error"
                 logger.error("Server error \(httpResponse.statusCode): \(msg)")
-                showStatus("Server error: \(httpResponse.statusCode)\n\(msg)", true)
+                showStatus("Server error: \(httpResponse.statusCode)\n\(msg)", true, nil)
                 return
             }
 
+            let bookmarkId = extractBookmarkId(from: httpResponse)
             if let resp = try? JSONDecoder().decode(CreateBookmarkResponseDto.self, from: data) {
-                logger.info("Bookmark created successfully: \(resp.message)")
-                showStatus("Saved: \(resp.message)", false)
+                logger.info("Bookmark created successfully: \(resp.message), id: \(bookmarkId ?? "unknown")")
+                showStatus("Saved: \(resp.message)", false, bookmarkId)
             } else {
-                logger.info("Bookmark created successfully")
-                showStatus("Bookmark saved!", false)
+                logger.info("Bookmark created successfully, id: \(bookmarkId ?? "unknown")")
+                showStatus("Bookmark saved!", false, bookmarkId)
             }
         } catch {
             logger.logNetworkError(method: "POST", url: "/api/bookmarks", error: error)
-            showStatus("Network error: \(error.localizedDescription)", true)
+            showStatus("Network error: \(error.localizedDescription)", true, nil)
         }
+    }
+
+    /// Reads the created bookmark's id from the response. Readeck returns it in the
+    /// `Bookmark-Id` header on `POST /bookmarks`; as a fallback we take the last path
+    /// component of the `Location` header (`/api/bookmarks/{id}`).
+    private static func extractBookmarkId(from response: HTTPURLResponse) -> String? {
+        if let id = response.value(forHTTPHeaderField: "Bookmark-Id"), !id.isEmpty {
+            return id
+        }
+        if let location = response.value(forHTTPHeaderField: "Location"),
+           let last = location.split(separator: "/").last.map(String.init),
+           !last.isEmpty {
+            return last
+        }
+        return nil
     }
 
     // swiftlint:disable:next discouraged_optional_collection

--- a/readeck/Data/Repository/BookmarksRepository.swift
+++ b/readeck/Data/Repository/BookmarksRepository.swift
@@ -27,6 +27,7 @@ final class BookmarksRepository: PBookmarksRepository {
             wordCount: bookmarkDetailDto.wordCount,
             readingTime: bookmarkDetailDto.readingTime,
             hasArticle: bookmarkDetailDto.hasArticle,
+            loaded: bookmarkDetailDto.loaded,
             isMarked: bookmarkDetailDto.isMarked,
             isArchived: bookmarkDetailDto.isArchived,
             labels: bookmarkDetailDto.labels,

--- a/readeck/Domain/Model/BookmarkDetail.swift
+++ b/readeck/Domain/Model/BookmarkDetail.swift
@@ -12,6 +12,10 @@ struct BookmarkDetail {
     let wordCount: Int?
     let readingTime: Int?
     let hasArticle: Bool
+    /// Whether the server has finished processing the bookmark. False right after
+    /// creation while Readeck fetches and extracts the page; flips to true once done
+    /// (even for photo/video bookmarks that never produce an article).
+    let loaded: Bool
     var isMarked: Bool
     var isArchived: Bool
     let labels: [String]
@@ -35,6 +39,7 @@ extension BookmarkDetail {
         wordCount: 0,
         readingTime: 0,
         hasArticle: false,
+        loaded: false,
         isMarked: false,
         isArchived: false,
         labels: [],

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -515,6 +515,7 @@ struct ArticleReaderLegacyView: View {
         }
         .task {
             await viewModel.loadBookmarkDetail(id: bookmarkId)
+            await viewModel.waitForArticleReady(id: bookmarkId)
             await viewModel.loadArticleContent(id: bookmarkId)
         }
     }

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -112,6 +112,7 @@ struct ArticleReaderView: View {
             }
             .task {
                 await viewModel.loadBookmarkDetail(id: bookmarkId)
+                await viewModel.waitForArticleReady(id: bookmarkId)
                 await viewModel.loadArticleContent(id: bookmarkId)
             }
     }

--- a/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
@@ -98,6 +98,34 @@ final class BookmarkDetailViewModel {
         isLoading = false
     }
 
+    /// After a bookmark is created the server fetches and extracts the page
+    /// asynchronously, so its article isn't available immediately. Polls the bookmark
+    /// until the server reports it as `loaded` (or an article shows up) so a freshly
+    /// shared article isn't rendered as a blank page. Returns at once when already
+    /// ready, so normal navigation is unaffected.
+    @MainActor
+    func waitForArticleReady(id: String, maxAttempts: Int = 8, delay: TimeInterval = 1.5) async {
+        guard !bookmarkDetail.loaded, !bookmarkDetail.hasArticle else { return }
+
+        isLoadingArticle = true
+        for attempt in 1...maxAttempts {
+            if Task.isCancelled { return }
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            do {
+                let refreshed = try await getBookmarkUseCase.execute(id: id)
+                bookmarkDetail = refreshed
+                readProgress = max(readProgress, refreshed.readProgress ?? 0)
+                if refreshed.loaded || refreshed.hasArticle {
+                    Logger.viewModel.info("📦 Bookmark \(id) ready after \(attempt) poll(s)")
+                    return
+                }
+            } catch {
+                // Transient (e.g. offline) — keep polling until the attempts run out.
+            }
+        }
+        Logger.viewModel.info("⏳ Bookmark \(id) still not loaded after \(maxAttempts) polls; showing as-is")
+    }
+
     @MainActor
     func loadArticleContent(id: String, forceRefresh: Bool = false) async {
         isLoadingArticle = true

--- a/readeck/UI/BookmarkDetail/DeepLinkReader.swift
+++ b/readeck/UI/BookmarkDetail/DeepLinkReader.swift
@@ -1,0 +1,55 @@
+//
+//  DeepLinkReader.swift
+//  readeck
+//
+//  Handles `readeck://bookmark/{id}` deep links (e.g. the Share Extension's
+//  "Open in Readeck" button) by presenting the article reader modally on top of
+//  whatever is on screen. Presenting rather than driving the per-tab navigation
+//  keeps the behaviour identical on iPhone and iPad and avoids reaching into each
+//  tab's private navigation state.
+//
+
+import SwiftUI
+import Observation
+
+@Observable
+final class DeepLinkRouter {
+    /// The bookmark to present, if any. Setting this opens the reader; the sheet
+    /// clears it again on dismiss.
+    var openedBookmark: DeepLinkedBookmark?
+
+    /// Parses a `readeck://bookmark/{id}` URL and, on success, requests the reader.
+    /// Ignores anything else (e.g. OAuth callbacks go through ASWebAuthenticationSession).
+    @discardableResult
+    func handle(url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "readeck", url.host?.lowercased() == "bookmark" else {
+            return false
+        }
+        let id = url.pathComponents.first { $0 != "/" && !$0.isEmpty }
+        guard let bookmarkId = id, !bookmarkId.isEmpty else { return false }
+        openedBookmark = DeepLinkedBookmark(id: bookmarkId)
+        return true
+    }
+}
+
+struct DeepLinkedBookmark: Identifiable, Equatable {
+    let id: String
+}
+
+/// Hosts the article reader inside its own navigation stack so it renders correctly
+/// when presented modally, with a leading button to close it.
+struct DeepLinkReaderView: View {
+    let bookmarkId: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ArticleReaderRouter(bookmarkId: bookmarkId)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+    }
+}

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -245,7 +245,7 @@ final class MockSaveSettingsUseCase: PSaveSettingsUseCase {
 
 final class MockGetBookmarkUseCase: PGetBookmarkUseCase {
     func execute(id: String) async throws -> BookmarkDetail {
-        BookmarkDetail(id: "123", title: "Test", url: "https://www.google.com", description: "Test", siteName: "Test", authors: ["Test"], created: "2021-01-01", updated: "2021-01-01", wordCount: 100, readingTime: 100, hasArticle: true, isMarked: false, isArchived: false, labels: ["Test"], thumbnailUrl: "https://picsum.photos/30/30", imageUrl: "https://picsum.photos/400/400", lang: "en", readProgress: 0)
+        BookmarkDetail(id: "123", title: "Test", url: "https://www.google.com", description: "Test", siteName: "Test", authors: ["Test"], created: "2021-01-01", updated: "2021-01-01", wordCount: 100, readingTime: 100, hasArticle: true, loaded: true, isMarked: false, isArchived: false, labels: ["Test"], thumbnailUrl: "https://picsum.photos/30/30", imageUrl: "https://picsum.photos/400/400", lang: "en", readProgress: 0)
     }
 }
 

--- a/readeck/UI/Menu/TabView.swift
+++ b/readeck/UI/Menu/TabView.swift
@@ -6,6 +6,8 @@ struct MainTabView: View {
     @State private var selectedBookmark: Bookmark?
     @State private var showReleaseNotes = false
 
+    @Environment(DeepLinkRouter.self) private var deepLinkRouter
+
     // sizeClass
     @Environment(\.horizontalSizeClass)
     private var horizontalSizeClass
@@ -14,6 +16,8 @@ struct MainTabView: View {
     private var verticalSizeClass
 
     var body: some View {
+        @Bindable var router = deepLinkRouter
+
         Group {
             if UIDevice.isPhone {
                 PhoneTabView()
@@ -23,6 +27,9 @@ struct MainTabView: View {
         }
         .sheet(isPresented: $showReleaseNotes) {
             ReleaseNotesView()
+        }
+        .sheet(item: $router.openedBookmark) { bookmark in
+            DeepLinkReaderView(bookmarkId: bookmark.id)
         }
         .onAppear {
             checkForNewVersion()
@@ -39,4 +46,5 @@ struct MainTabView: View {
 
 #Preview {
     MainTabView()
+        .environment(DeepLinkRouter())
 }

--- a/readeck/UI/readeckApp.swift
+++ b/readeck/UI/readeckApp.swift
@@ -12,6 +12,7 @@ import netfox
 struct readeckApp: App {
     @State private var appViewModel = AppViewModel()
     @StateObject private var appSettings = AppSettings()
+    @State private var deepLinkRouter = DeepLinkRouter()
     @Environment(\.scenePhase) private var scenePhase
     @State private var showDebugMenu = false
 
@@ -26,8 +27,12 @@ struct readeckApp: App {
                 }
             }
             .environmentObject(appSettings)
+            .environment(deepLinkRouter)
             .environment(\.managedObjectContext, CoreDataManager.shared.context)
             .preferredColorScheme(appSettings.theme.colorScheme)
+            .onOpenURL { url in
+                deepLinkRouter.handle(url: url)
+            }
             .onShake {
                 // Only show debug menu in non-production builds (DEBUG + TestFlight)
                 if !Bundle.main.isProduction {

--- a/readeckTests/Helpers/ConfigurableMocks.swift
+++ b/readeckTests/Helpers/ConfigurableMocks.swift
@@ -61,7 +61,7 @@ class ConfigurableDeleteBookmarkUseCase: PDeleteBookmarkUseCase {
 
 class ConfigurableGetBookmarkUseCase: PGetBookmarkUseCase {
     var result: Result<BookmarkDetail, Error> = .success(
-        BookmarkDetail(id: "123", title: "Test", url: "https://example.com", description: "Test", siteName: "Test", authors: ["Test"], created: "2021-01-01", updated: "2021-01-01", wordCount: 100, readingTime: 2, hasArticle: true, isMarked: false, isArchived: false, labels: [], thumbnailUrl: "", imageUrl: "", lang: "en", readProgress: 0)
+        BookmarkDetail(id: "123", title: "Test", url: "https://example.com", description: "Test", siteName: "Test", authors: ["Test"], created: "2021-01-01", updated: "2021-01-01", wordCount: 100, readingTime: 2, hasArticle: true, loaded: true, isMarked: false, isArchived: false, labels: [], thumbnailUrl: "", imageUrl: "", lang: "en", readProgress: 0)
     )
 
     func execute(id: String) async throws -> BookmarkDetail {

--- a/readeckTests/Navigation/DeepLinkRouterTests.swift
+++ b/readeckTests/Navigation/DeepLinkRouterTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("DeepLinkRouter")
+struct DeepLinkRouterTests {
+
+    @Test("Parses readeck://bookmark/{id} and opens the reader")
+    func handlesBookmarkDeepLink() {
+        let router = DeepLinkRouter()
+        let handled = router.handle(url: URL(string: "readeck://bookmark/abc123")!)
+        #expect(handled == true)
+        #expect(router.openedBookmark == DeepLinkedBookmark(id: "abc123"))
+    }
+
+    @Test("Scheme is matched case-insensitively")
+    func handlesUppercaseScheme() {
+        let router = DeepLinkRouter()
+        let handled = router.handle(url: URL(string: "Readeck://Bookmark/xyz")!)
+        #expect(handled == true)
+        #expect(router.openedBookmark?.id == "xyz")
+    }
+
+    @Test("Ignores non-bookmark hosts (e.g. OAuth callbacks)")
+    func ignoresOtherHosts() {
+        let router = DeepLinkRouter()
+        let handled = router.handle(url: URL(string: "readeck://oauth/callback?code=1")!)
+        #expect(handled == false)
+        #expect(router.openedBookmark == nil)
+    }
+
+    @Test("Ignores a missing bookmark id")
+    func ignoresMissingId() {
+        let router = DeepLinkRouter()
+        let handled = router.handle(url: URL(string: "readeck://bookmark")!)
+        #expect(handled == false)
+        #expect(router.openedBookmark == nil)
+    }
+
+    @Test("Ignores foreign schemes")
+    func ignoresForeignScheme() {
+        let router = DeepLinkRouter()
+        let handled = router.handle(url: URL(string: "https://bookmark/abc")!)
+        #expect(handled == false)
+        #expect(router.openedBookmark == nil)
+    }
+}

--- a/readeckTests/ViewModels/BookmarkDetailViewModelTests.swift
+++ b/readeckTests/ViewModels/BookmarkDetailViewModelTests.swift
@@ -29,6 +29,7 @@ struct BookmarkDetailViewModelTests {
             wordCount: 500,
             readingTime: 5,
             hasArticle: true,
+            loaded: true,
             isMarked: false,
             isArchived: false,
             labels: [],


### PR DESCRIPTION
After a bookmark is saved via the Share Extension, it now shows an **"Open in Readeck"** button that jumps straight into the article.

**Extension**
- Reads the new bookmark's id from the `Bookmark-Id` response header (falls back to `Location`).
- Tapping opens `readeck://bookmark/{id}` and cancels the auto-close; the auto-close timer is extended so there's time to tap.
- Opens the host app by walking the responder chain to the real `UIApplication` and calling the non-deprecated `open(_:options:completionHandler:)` — on iOS 18 the old `openURL:` is forced to a no-op, and the `UIApplication` cast skips SwiftUI's hosting view (which would otherwise swallow the call).

**App**
- A small `DeepLinkRouter` handles the URL in `.onOpenURL` and presents the reader modally — identical on iPhone and iPad, no per-tab navigation surgery.
- A freshly created bookmark is processed server-side asynchronously, so the reader used to show a blank page. `BookmarkDetail` now carries the server's `loaded` flag and the reader polls until the bookmark is ready before rendering. Returns immediately when already loaded, so normal navigation is unaffected.

Gracefully degrades on older servers that don't return the id (no button, quick auto-close as before). Unit-tested URL parsing and detail loading; verified end-to-end on device.

Closes #68
