### PR TITLE
feat(settings): add Contributors screen (#71)

### DIFF
--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -289,3 +289,8 @@
 "Open Next Article" = "Nächsten Artikel öffnen";
 "Return to List" = "Zurück zur Liste";
 "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Lege fest, was passiert, wenn du den gerade gelesenen Artikel archivierst oder löschst: beim Artikel bleiben, den nächsten in deiner Liste öffnen oder zur Liste zurückkehren.";
+
+// Contributors screen
+"Contributors" = "Mitwirkende";
+"Maintainer" = "Maintainer";
+"Thanks to everyone who has contributed to the app." = "Danke an alle, die zur App beigetragen haben.";

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -290,7 +290,8 @@
 "Return to List" = "Zurück zur Liste";
 "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Lege fest, was passiert, wenn du den gerade gelesenen Artikel archivierst oder löschst: beim Artikel bleiben, den nächsten in deiner Liste öffnen oder zur Liste zurückkehren.";
 
-// Contributors screen
+// Contributors / Hall of Fame screen
+"Hall of Fame" = "Hall of Fame";
 "Contributors" = "Mitwirkende";
 "Maintainer" = "Maintainer";
 "Thanks to everyone who has contributed to the app." = "Danke an alle, die zur App beigetragen haben.";

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -294,4 +294,6 @@
 "Hall of Fame" = "Hall of Fame";
 "Contributors" = "Mitwirkende";
 "Maintainer" = "Maintainer";
+"The Readeck Project" = "Das Readeck-Projekt";
+"Creator of Readeck" = "Schöpfer von Readeck";
 "Thanks to everyone who has contributed to the app." = "Danke an alle, die zur App beigetragen haben.";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -281,3 +281,8 @@
 "Open Next Article" = "Open Next Article";
 "Return to List" = "Return to List";
 "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list.";
+
+// Contributors screen
+"Contributors" = "Contributors";
+"Maintainer" = "Maintainer";
+"Thanks to everyone who has contributed to the app." = "Thanks to everyone who has contributed to the app.";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -286,4 +286,6 @@
 "Hall of Fame" = "Hall of Fame";
 "Contributors" = "Contributors";
 "Maintainer" = "Maintainer";
+"The Readeck Project" = "The Readeck Project";
+"Creator of Readeck" = "Creator of Readeck";
 "Thanks to everyone who has contributed to the app." = "Thanks to everyone who has contributed to the app.";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -282,7 +282,8 @@
 "Return to List" = "Return to List";
 "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list." = "Choose what happens when you archive or delete the article you're reading: stay on it, open the next one in your list, or return to the list.";
 
-// Contributors screen
+// Contributors / Hall of Fame screen
+"Hall of Fame" = "Hall of Fame";
 "Contributors" = "Contributors";
 "Maintainer" = "Maintainer";
 "Thanks to everyone who has contributed to the app." = "Thanks to everyone who has contributed to the app.";

--- a/readeck/UI/Resources/RELEASE_NOTES.md
+++ b/readeck/UI/Resources/RELEASE_NOTES.md
@@ -4,9 +4,39 @@ Thanks for using the Readeck iOS app! Below are the release notes for each versi
 
 **AppStore:** The App is now in the App Store! [Get it here](https://apps.apple.com/de/app/readeck/id6748764703) for all TestFlight users. If you wish a more stable Version, please download it from there. Or you can continue using TestFlight for the latest features.
 
-## Unreleased
+## Version 3.1.0
 
-- Added a Delete option to the article reading view's menu, so you can remove the current article without going back to the list.
+### Unread Count Badge
+
+- **Optional app-icon badge** showing your number of unread articles
+- Mirrors the Unread tab and refreshes when you open the app or archive/delete an article
+- Turn it on in Settings → Reading Settings ("Show Unread Count on App Icon"); off by default
+
+### "After Archiving" Options
+
+- **Choose what happens when you archive or delete the article you're reading:** stay on it, open the next one in your list, or return to the list
+- New picker in Settings → Reading Settings
+
+### Open Saved Articles from the Share Sheet
+
+- After saving a link via the **Share Extension**, tap **"Open in Readeck"** to jump straight into the article
+- The reader waits for the server to finish preparing a freshly saved article instead of showing a blank page
+
+### Reader
+
+- Added a **Delete** option to the article reading view's menu, so you can remove the current article without going back to the list
+
+### Hall of Fame
+
+- New **Settings → Hall of Fame** screen crediting the Readeck project founder, the app maintainer, and everyone who has contributed
+- Tap a person to open their GitHub or Codeberg profile
+
+### Bug Fixes & Stability
+
+- More robust OAuth login (clearer retries, guards against double taps)
+- More defensive handling of the server info/version response
+- Automatic recovery from transient gateway errors (502/503/504 and Cloudflare 52x) when loading large articles
+- The bookmark type filter (Articles/Videos/Pictures) is now preserved when the list reloads
 
 ## Version 3.0.0
 

--- a/readeck/UI/Settings/ContributorsView.swift
+++ b/readeck/UI/Settings/ContributorsView.swift
@@ -76,7 +76,7 @@ struct ContributorsView: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 32)
             }
-            .navigationTitle("Contributors")
+            .navigationTitle("Hall of Fame")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {

--- a/readeck/UI/Settings/ContributorsView.swift
+++ b/readeck/UI/Settings/ContributorsView.swift
@@ -85,13 +85,13 @@ struct ContributorsView: View {
                         .padding(.top, 8)
 
                     VStack(spacing: 12) {
-                        sectionTitle("The Readeck Project")
-                        ContributorCell(contributor: Contributors.founder, avatarSize: 96)
+                        sectionTitle("Maintainer")
+                        ContributorCell(contributor: Contributors.maintainer, avatarSize: 96)
                     }
 
                     VStack(spacing: 12) {
-                        sectionTitle("Maintainer")
-                        ContributorCell(contributor: Contributors.maintainer, avatarSize: 96)
+                        sectionTitle("The Readeck Project")
+                        ContributorCell(contributor: Contributors.founder, avatarSize: 72)
                     }
 
                     VStack(spacing: 16) {

--- a/readeck/UI/Settings/ContributorsView.swift
+++ b/readeck/UI/Settings/ContributorsView.swift
@@ -1,0 +1,155 @@
+//
+//  ContributorsView.swift
+//  readeck
+//
+//  A small thank-you / credits screen listing everyone who has contributed
+//  to the app across both remotes (GitHub + Codeberg).
+//
+//  The list is a curated static array (single source of truth): both remotes
+//  have separate histories with duplicate/no-reply identities that need manual
+//  dedup, and the git history isn't available in the app bundle at runtime.
+//
+//  Avatars are loaded from GitHub via Kingfisher (cached after first load, so
+//  they keep working offline). A round person placeholder is shown while
+//  loading or when offline without a cached avatar.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct Contributor: Identifiable {
+    /// GitHub username — used to derive both the profile and avatar URLs.
+    let login: String
+    let name: String
+
+    var id: String { login }
+    var handle: String { "@\(login)" }
+    var profileURL: URL? { URL(string: "https://github.com/\(login)") }
+    var avatarURL: URL? { URL(string: "https://github.com/\(login).png?size=200") }
+}
+
+enum Contributors {
+    static let maintainer = Contributor(login: "ilyas-hallak", name: "Ilyas Hallak")
+
+    // Alphabetical by name. Extend this as new contributions land.
+    static let others: [Contributor] = [
+        Contributor(login: "bakerboy448", name: "bakerboy448"),
+        Contributor(login: "benrhughes", name: "Ben Hughes"),
+        Contributor(login: "christian-putzke", name: "Christian Putzke"),
+        Contributor(login: "ishansharma", name: "Ishan Sharma"),
+        Contributor(login: "grabowskil", name: "Lennart Grabowski"),
+        Contributor(login: "sibson", name: "Marc Sibson"),
+        Contributor(login: "astratto", name: "Stefano Tortarolo")
+    ]
+}
+
+struct ContributorsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let columns = [GridItem(.adaptive(minimum: 96), spacing: 20)]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 28) {
+                    Text("Thanks to everyone who has contributed to the app.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 8)
+
+                    VStack(spacing: 12) {
+                        sectionTitle("Maintainer")
+                        ContributorCell(contributor: Contributors.maintainer, avatarSize: 96)
+                    }
+
+                    VStack(spacing: 16) {
+                        sectionTitle("Contributors")
+                        LazyVGrid(columns: columns, spacing: 24) {
+                            ForEach(Contributors.others) { contributor in
+                                ContributorCell(contributor: contributor, avatarSize: 72)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 32)
+            }
+            .navigationTitle("Contributors")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func sectionTitle(_ key: LocalizedStringKey) -> some View {
+        Text(key)
+            .font(.footnote.weight(.semibold))
+            .foregroundColor(.secondary)
+            .textCase(.uppercase)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct ContributorCell: View {
+    let contributor: Contributor
+    let avatarSize: CGFloat
+
+    var body: some View {
+        Button {
+            if let url = contributor.profileURL {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            VStack(spacing: 8) {
+                avatar
+                VStack(spacing: 2) {
+                    Text(contributor.name)
+                        .font(.footnote.weight(.medium))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    Text(contributor.handle)
+                        .font(.caption2)
+                        .foregroundColor(.blue)
+                        .lineLimit(1)
+                }
+                .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var avatar: some View {
+        KFImage(contributor.avatarURL)
+            .placeholder { placeholder }
+            .fade(duration: 0.2)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: avatarSize, height: avatarSize)
+            .clipShape(Circle())
+            .overlay(Circle().stroke(Color.primary.opacity(0.1), lineWidth: 0.5))
+    }
+
+    private var placeholder: some View {
+        Circle()
+            .fill(Color.gray.opacity(0.2))
+            .frame(width: avatarSize, height: avatarSize)
+            .overlay(
+                Image(systemName: "person.fill")
+                    .font(.system(size: avatarSize * 0.4))
+                    .foregroundColor(.gray)
+            )
+    }
+}
+
+#Preview {
+    ContributorsView()
+}

--- a/readeck/UI/Settings/ContributorsView.swift
+++ b/readeck/UI/Settings/ContributorsView.swift
@@ -2,44 +2,69 @@
 //  ContributorsView.swift
 //  readeck
 //
-//  A small thank-you / credits screen listing everyone who has contributed
+//  A small thank-you / credits screen ("Hall of Fame") listing the Readeck
+//  project founder, this client's maintainer, and everyone who has contributed
 //  to the app across both remotes (GitHub + Codeberg).
 //
 //  The list is a curated static array (single source of truth): both remotes
 //  have separate histories with duplicate/no-reply identities that need manual
 //  dedup, and the git history isn't available in the app bundle at runtime.
 //
-//  Avatars are loaded from GitHub via Kingfisher (cached after first load, so
-//  they keep working offline). A round person placeholder is shown while
-//  loading or when offline without a cached avatar.
+//  Avatars are loaded via Kingfisher from each person's platform
+//  (github.com/<login>.png or codeberg.org/<login>.png), cached after first
+//  load so the screen keeps working offline; a round person placeholder is
+//  shown while loading or when offline without a cached avatar.
 //
 
 import SwiftUI
 import Kingfisher
 
 struct Contributor: Identifiable {
-    /// GitHub username — used to derive both the profile and avatar URLs.
-    let login: String
     let name: String
+    let handle: String
+    let profileURL: URL?
+    let avatarURL: URL?
+    /// Optional role line (e.g. "Creator of Readeck").
+    let note: String?
 
-    var id: String { login }
-    var handle: String { "@\(login)" }
-    var profileURL: URL? { URL(string: "https://github.com/\(login)") }
-    var avatarURL: URL? { URL(string: "https://github.com/\(login).png?size=200") }
+    var id: String { handle }
+
+    static func github(_ login: String, name: String, note: String? = nil) -> Contributor {
+        Contributor(
+            name: name,
+            handle: "@\(login)",
+            profileURL: URL(string: "https://github.com/\(login)"),
+            avatarURL: URL(string: "https://github.com/\(login).png?size=200"),
+            note: note
+        )
+    }
+
+    static func codeberg(_ login: String, name: String, note: String? = nil) -> Contributor {
+        Contributor(
+            name: name,
+            handle: "@\(login)",
+            profileURL: URL(string: "https://codeberg.org/\(login)"),
+            avatarURL: URL(string: "https://codeberg.org/\(login).png"),
+            note: note
+        )
+    }
 }
 
 enum Contributors {
-    static let maintainer = Contributor(login: "ilyas-hallak", name: "Ilyas Hallak")
+    /// Creator of the upstream Readeck project this client connects to.
+    static let founder = Contributor.codeberg("olivier", name: "Olivier Meunier", note: "Creator of Readeck")
+
+    static let maintainer = Contributor.github("ilyas-hallak", name: "Ilyas Hallak")
 
     // Alphabetical by name. Extend this as new contributions land.
     static let others: [Contributor] = [
-        Contributor(login: "bakerboy448", name: "bakerboy448"),
-        Contributor(login: "benrhughes", name: "Ben Hughes"),
-        Contributor(login: "christian-putzke", name: "Christian Putzke"),
-        Contributor(login: "ishansharma", name: "Ishan Sharma"),
-        Contributor(login: "grabowskil", name: "Lennart Grabowski"),
-        Contributor(login: "sibson", name: "Marc Sibson"),
-        Contributor(login: "astratto", name: "Stefano Tortarolo")
+        .github("bakerboy448", name: "bakerboy448"),
+        .github("benrhughes", name: "Ben Hughes"),
+        .github("christian-putzke", name: "Christian Putzke"),
+        .github("ishansharma", name: "Ishan Sharma"),
+        .github("grabowskil", name: "Lennart Grabowski"),
+        .github("sibson", name: "Marc Sibson"),
+        .github("astratto", name: "Stefano Tortarolo")
     ]
 }
 
@@ -58,6 +83,11 @@ struct ContributorsView: View {
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
                         .padding(.top, 8)
+
+                    VStack(spacing: 12) {
+                        sectionTitle("The Readeck Project")
+                        ContributorCell(contributor: Contributors.founder, avatarSize: 96)
+                    }
 
                     VStack(spacing: 12) {
                         sectionTitle("Maintainer")
@@ -119,6 +149,12 @@ struct ContributorCell: View {
                         .font(.caption2)
                         .foregroundColor(.blue)
                         .lineLimit(1)
+                    if let note = contributor.note {
+                        Text(LocalizedStringKey(note))
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
                 }
                 .multilineTextAlignment(.center)
             }

--- a/readeck/UI/Settings/LegalPrivacySettingsView.swift
+++ b/readeck/UI/Settings/LegalPrivacySettingsView.swift
@@ -1,16 +1,20 @@
 import SwiftUI
 
+/// Which modal is presented from the legal/about section.
+///
+/// Presentation is driven from a single `.sheet(item:)` attached to the
+/// top-level `List` in `SettingsContainerView` (a stable ancestor). Attaching
+/// the sheet here — inside a `List` section — makes the first presentation get
+/// cancelled because the section view is rebuilt as the sheet appears (the
+/// sheet opened and closed immediately, only working on the second tap).
+enum SettingsSheet: Identifiable {
+    case releaseNotes, privacy, legalNotice, licenses, contributors
+
+    var id: Int { hashValue }
+}
+
 struct LegalPrivacySettingsView: View {
-    // Single source of truth for the presented sheet. Using one `.sheet(item:)`
-    // instead of several `.sheet(isPresented:)` on the same view avoids a
-    // SwiftUI bug where all but the last sheet dismiss immediately on first tap.
-    private enum ActiveSheet: Identifiable {
-        case releaseNotes, privacy, legalNotice, licenses, contributors
-
-        var id: Int { hashValue }
-    }
-
-    @State private var activeSheet: ActiveSheet?
+    @Binding var activeSheet: SettingsSheet?
 
     var body: some View {
         Group {
@@ -109,26 +113,12 @@ struct LegalPrivacySettingsView: View {
                 Text("Legal, Privacy & Support")
             }
         }
-        .sheet(item: $activeSheet) { sheet in
-            switch sheet {
-            case .releaseNotes:
-                ReleaseNotesView()
-            case .privacy:
-                PrivacyPolicyView()
-            case .legalNotice:
-                LegalNoticeView()
-            case .licenses:
-                OpenSourceLicensesView()
-            case .contributors:
-                ContributorsView()
-            }
-        }
     }
 }
 
 #Preview {
     List {
-        LegalPrivacySettingsView()
+        LegalPrivacySettingsView(activeSheet: .constant(nil))
     }
     .listStyle(.insetGrouped)
 }

--- a/readeck/UI/Settings/LegalPrivacySettingsView.swift
+++ b/readeck/UI/Settings/LegalPrivacySettingsView.swift
@@ -1,17 +1,22 @@
 import SwiftUI
 
 struct LegalPrivacySettingsView: View {
-    @State private var showingPrivacyPolicy = false
-    @State private var showingLegalNotice = false
-    @State private var showReleaseNotes = false
-    @State private var showingLicenses = false
-    @State private var showingContributors = false
+    // Single source of truth for the presented sheet. Using one `.sheet(item:)`
+    // instead of several `.sheet(isPresented:)` on the same view avoids a
+    // SwiftUI bug where all but the last sheet dismiss immediately on first tap.
+    private enum ActiveSheet: Identifiable {
+        case releaseNotes, privacy, legalNotice, licenses, contributors
+
+        var id: Int { hashValue }
+    }
+
+    @State private var activeSheet: ActiveSheet?
 
     var body: some View {
         Group {
             Section {
                 Button(action: {
-                    showReleaseNotes = true
+                    activeSheet = .releaseNotes
                 }) {
                     HStack {
                         Text("What's New")
@@ -26,7 +31,7 @@ struct LegalPrivacySettingsView: View {
                 }
 
                 Button(action: {
-                    showingPrivacyPolicy = true
+                    activeSheet = .privacy
                 }) {
                     HStack {
                         Text(NSLocalizedString("Privacy Policy", comment: ""))
@@ -38,7 +43,7 @@ struct LegalPrivacySettingsView: View {
                 }
 
                 Button(action: {
-                    showingLegalNotice = true
+                    activeSheet = .legalNotice
                 }) {
                     HStack {
                         Text(NSLocalizedString("Legal Notice", comment: ""))
@@ -50,7 +55,7 @@ struct LegalPrivacySettingsView: View {
                 }
 
                 Button(action: {
-                    showingLicenses = true
+                    activeSheet = .licenses
                 }) {
                     HStack {
                         Text("Open Source Licenses")
@@ -62,7 +67,7 @@ struct LegalPrivacySettingsView: View {
                 }
 
                 Button(action: {
-                    showingContributors = true
+                    activeSheet = .contributors
                 }) {
                     HStack {
                         Text("Hall of Fame")
@@ -104,20 +109,19 @@ struct LegalPrivacySettingsView: View {
                 Text("Legal, Privacy & Support")
             }
         }
-        .sheet(isPresented: $showingPrivacyPolicy) {
-            PrivacyPolicyView()
-        }
-        .sheet(isPresented: $showingLegalNotice) {
-            LegalNoticeView()
-        }
-        .sheet(isPresented: $showReleaseNotes) {
-            ReleaseNotesView()
-        }
-        .sheet(isPresented: $showingLicenses) {
-            OpenSourceLicensesView()
-        }
-        .sheet(isPresented: $showingContributors) {
-            ContributorsView()
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .releaseNotes:
+                ReleaseNotesView()
+            case .privacy:
+                PrivacyPolicyView()
+            case .legalNotice:
+                LegalNoticeView()
+            case .licenses:
+                OpenSourceLicensesView()
+            case .contributors:
+                ContributorsView()
+            }
         }
     }
 }

--- a/readeck/UI/Settings/LegalPrivacySettingsView.swift
+++ b/readeck/UI/Settings/LegalPrivacySettingsView.swift
@@ -5,6 +5,7 @@ struct LegalPrivacySettingsView: View {
     @State private var showingLegalNotice = false
     @State private var showReleaseNotes = false
     @State private var showingLicenses = false
+    @State private var showingContributors = false
 
     var body: some View {
         Group {
@@ -61,6 +62,18 @@ struct LegalPrivacySettingsView: View {
                 }
 
                 Button(action: {
+                    showingContributors = true
+                }) {
+                    HStack {
+                        Text("Contributors")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Button(action: {
                     if let url = URL(string: "https://github.com/ilyas-hallak/readeck-ios/issues") {
                         UIApplication.shared.open(url)
                     }
@@ -102,6 +115,9 @@ struct LegalPrivacySettingsView: View {
         }
         .sheet(isPresented: $showingLicenses) {
             OpenSourceLicensesView()
+        }
+        .sheet(isPresented: $showingContributors) {
+            ContributorsView()
         }
     }
 }

--- a/readeck/UI/Settings/LegalPrivacySettingsView.swift
+++ b/readeck/UI/Settings/LegalPrivacySettingsView.swift
@@ -65,7 +65,7 @@ struct LegalPrivacySettingsView: View {
                     showingContributors = true
                 }) {
                     HStack {
-                        Text("Contributors")
+                        Text("Hall of Fame")
                         Spacer()
                         Image(systemName: "chevron.right")
                             .font(.caption)

--- a/readeck/UI/Settings/SettingsContainerView.swift
+++ b/readeck/UI/Settings/SettingsContainerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsContainerView: View {
     @State private var offlineViewModel = OfflineSettingsViewModel()
+    @State private var activeSheet: SettingsSheet?
 
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -86,7 +87,7 @@ struct SettingsContainerView: View {
 
             SettingsServerView()
 
-            LegalPrivacySettingsView()
+            LegalPrivacySettingsView(activeSheet: $activeSheet)
 
             // Debug-only Settings Section
             if !Bundle.main.isProduction {
@@ -101,6 +102,22 @@ struct SettingsContainerView: View {
         .navigationBarTitleDisplayMode(.large)
         .task {
             await offlineViewModel.loadSettings()
+        }
+        // Presented from a stable ancestor (this List) so the first
+        // presentation isn't cancelled by a section rebuild.
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .releaseNotes:
+                ReleaseNotesView()
+            case .privacy:
+                PrivacyPolicyView()
+            case .legalNotice:
+                LegalNoticeView()
+            case .licenses:
+                OpenSourceLicensesView()
+            case .contributors:
+                ContributorsView()
+            }
         }
     }
 


### PR DESCRIPTION
Closes #71

## Summary
Adds a **Contributors** credits screen under Settings, reachable next to *Open Source Licenses* / *Legal Notice*.

- Maintainer shown on top; other contributors in a GitHub-style grid of **round avatars** with name + `@handle`.
- Tapping a cell opens the person's GitHub profile.
- Avatars load from GitHub via **Kingfisher** (cached after first load → still renders offline) with a person placeholder.
- `KFImage` used directly instead of `CachedAsyncImage` to avoid attaching the readeck server bearer token to `github.com` requests.
- Contributor list is a curated static array, deduped across both remotes (GitHub + Codeberg).
- Title, section headers and intro localized **en/de**.

## Testing
- `xcodebuild` build succeeds for simulator + device.
- Deployed to a physical device for manual verification.