### PR TITLE
fix(reader): dark-mode highlight overlay label color (Codeberg #43)

### DIFF
--- a/readeck/UI/Components/NativeWebView.swift
+++ b/readeck/UI/Components/NativeWebView.swift
@@ -428,7 +428,7 @@ struct NativeWebView: View {
                 \(generateScrollToAnnotationJS())
 
                 // Text Selection and Annotation Overlay
-                \(generateAnnotationOverlayJS(isDarkMode: isDarkMode))
+                \(generateAnnotationOverlayJS(isDarkMode: isDarkMode, textColor: resolvedTextColor))
             </script>
         </body>
         </html>
@@ -453,7 +453,7 @@ struct NativeWebView: View {
         }
     }
 
-    private func generateAnnotationOverlayJS(isDarkMode: Bool) -> String {
+    private func generateAnnotationOverlayJS(isDarkMode: Bool, textColor: String) -> String {
         let highlightLabel = NSLocalizedString("Highlight", comment: "")
 
         return """
@@ -514,7 +514,7 @@ struct NativeWebView: View {
             const label = document.createElement('span');
             label.textContent = '\(highlightLabel)';
             label.style.cssText = `
-                color: black;
+                color: \(textColor);
                 font-size: 16px;
                 font-weight: 500;
                 margin-right: 4px;

--- a/readeck/UI/Components/WebView.swift
+++ b/readeck/UI/Components/WebView.swift
@@ -497,7 +497,7 @@ struct WebView: UIViewRepresentable {
             const label = document.createElement('span');
             label.textContent = '\(highlightLabel)';
             label.style.cssText = `
-                color: black;
+                color: var(--text-color);
                 font-size: 16px;
                 font-weight: 500;
                 margin-right: 4px;


### PR DESCRIPTION
The highlight popup showed its "Highlight" label in black, so in dark mode you basically couldn't read it.

Now it just uses the reader's own text color, so it looks right on every theme — dark, light, sepia, custom. A plain black→white swap would've just broken light/sepia instead, so this way it's always readable.

Fixes Codeberg #43.