### PR TITLE
fix(cache): enforce image cache size limit + clarify cache labels (Codeberg #44)

### DIFF
--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -491,6 +491,21 @@ final class SettingsRepository: PSettingsRepository {
         KingfisherManager.shared.cache.diskStorage.config.sizeLimit = sizeInBytes
         userDefault.set(sizeInBytes, forKey: maxCacheSizeKey)
         logger.info("Updated max cache size to \(sizeInBytes) bytes")
+        // Trim right away so lowering the limit takes effect immediately.
+        await KingfisherManager.shared.cache.cleanExpiredDiskCache()
+    }
+
+    /// Applies the persisted max image-cache size to Kingfisher's disk cache and
+    /// evicts least-recently-used images until the cache is within the limit.
+    ///
+    /// Kingfisher only enforces `sizeLimit` during a cleanup pass, and the limit
+    /// was previously set only when the user moved the slider — so across app
+    /// launches the cap was never applied and the image cache could grow far
+    /// beyond the configured maximum (Codeberg #44).
+    func applyCacheSizeLimit() async throws {
+        let sizeLimit = try await getMaxCacheSize()
+        KingfisherManager.shared.cache.diskStorage.config.sizeLimit = sizeLimit
+        await KingfisherManager.shared.cache.cleanExpiredDiskCache()
     }
 
     func clearCache() async throws {

--- a/readeck/Domain/Protocols/PSettingsRepository.swift
+++ b/readeck/Domain/Protocols/PSettingsRepository.swift
@@ -32,4 +32,7 @@ protocol PSettingsRepository {
     func getMaxCacheSize() async throws -> UInt
     func updateMaxCacheSize(_ sizeInBytes: UInt) async throws
     func clearCache() async throws
+    /// Applies the persisted max image-cache size to Kingfisher and evicts
+    /// least-recently-used images until the cache is within the limit.
+    func applyCacheSizeLimit() async throws
 }

--- a/readeck/Domain/UseCase/Cache/ApplyCacheSizeLimitUseCase.swift
+++ b/readeck/Domain/UseCase/Cache/ApplyCacheSizeLimitUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol PApplyCacheSizeLimitUseCase {
+    func execute() async throws
+}
+
+/// Applies the configured max image-cache size to the on-disk image cache and
+/// evicts least-recently-used images until the cache is within the limit.
+///
+/// Used at app launch so the limit is enforced across restarts (Codeberg #44).
+final class ApplyCacheSizeLimitUseCase: PApplyCacheSizeLimitUseCase {
+    private let settingsRepository: PSettingsRepository
+
+    init(settingsRepository: PSettingsRepository) {
+        self.settingsRepository = settingsRepository
+    }
+
+    func execute() async throws {
+        try await settingsRepository.applyCacheSizeLimit()
+    }
+}

--- a/readeck/Domain/UseCase/Offline/OfflineCacheSyncUseCase.swift
+++ b/readeck/Domain/UseCase/Offline/OfflineCacheSyncUseCase.swift
@@ -162,6 +162,10 @@ final class OfflineCacheSyncUseCase: POfflineCacheSyncUseCase {
             // Cleanup old articles (FIFO)
             try await offlineCacheRepository.cleanupOldestCachedArticles(keepCount: settings.maxUnreadArticlesInt)
 
+            // Enforce the configured image-cache size limit after prefetching
+            // article images, so the image cache stays within the maximum (#44).
+            try? await settingsRepository.applyCacheSizeLimit()
+
             // Update last sync date in settings
             var updatedSettings = settings
             updatedSettings.lastSyncDate = Date()

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -43,6 +43,8 @@
 "Font Settings" = "Schriftart";
 "Appearance" = "Darstellung";
 "Cache Settings" = "Cache";
+"Image Cache" = "Bild-Cache";
+"Article Content" = "Artikelinhalt";
 "General Settings" = "Allgemein";
 "Server Settings" = "Server";
 "Server Connection" = "Server-Verbindung";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "Font Settings" = "Font Settings";
 "Appearance" = "Appearance";
 "Cache Settings" = "Cache Settings";
+"Image Cache" = "Image Cache";
+"Article Content" = "Article Content";
 "General Settings" = "General Settings";
 "Server Settings" = "Server Settings";
 "Server Connection" = "Server Connection";

--- a/readeck/UI/Debug/DebugMenuView.swift
+++ b/readeck/UI/Debug/DebugMenuView.swift
@@ -261,7 +261,7 @@ struct DebugMenuView: View {
             }
 
             HStack {
-                Text("Cache Size")
+                Text("Article Content")
                 Spacer()
                 Text(viewModel.cacheSize)
                     .foregroundColor(.secondary)

--- a/readeck/UI/Factory/DefaultUseCaseFactory.swift
+++ b/readeck/UI/Factory/DefaultUseCaseFactory.swift
@@ -36,6 +36,7 @@ protocol UseCaseFactory {
     func makeGetMaxCacheSizeUseCase() -> PGetMaxCacheSizeUseCase
     func makeUpdateMaxCacheSizeUseCase() -> PUpdateMaxCacheSizeUseCase
     func makeClearCacheUseCase() -> PClearCacheUseCase
+    func makeApplyCacheSizeLimitUseCase() -> PApplyCacheSizeLimitUseCase
     func makeLoginWithOAuthUseCase() -> PLoginWithOAuthUseCase
     func makeAuthRepository() -> PAuthRepository
     func makeSummarizeArticleUseCase() -> PSummarizeArticleUseCase
@@ -201,6 +202,10 @@ final class DefaultUseCaseFactory: UseCaseFactory {
 
     func makeUpdateMaxCacheSizeUseCase() -> PUpdateMaxCacheSizeUseCase {
         UpdateMaxCacheSizeUseCase(settingsRepository: settingsRepository)
+    }
+
+    func makeApplyCacheSizeLimitUseCase() -> PApplyCacheSizeLimitUseCase {
+        ApplyCacheSizeLimitUseCase(settingsRepository: settingsRepository)
     }
 
     func makeClearCacheUseCase() -> PClearCacheUseCase {

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -370,6 +370,7 @@ final class MockSettingsRepository: PSettingsRepository {
     func getMaxCacheSize() async throws -> UInt { 200 * 1024 * 1024 }
     func updateMaxCacheSize(_ sizeInBytes: UInt) async throws {}
     func clearCache() async throws {}
+    func applyCacheSizeLimit() async throws {}
 }
 
 final class MockOfflineCacheSyncUseCase: POfflineCacheSyncUseCase {

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -145,6 +145,10 @@ final class MockUseCaseFactory: UseCaseFactory {
         MockUpdateMaxCacheSizeUseCase()
     }
 
+    func makeApplyCacheSizeLimitUseCase() -> PApplyCacheSizeLimitUseCase {
+        MockApplyCacheSizeLimitUseCase()
+    }
+
     func makeClearCacheUseCase() -> PClearCacheUseCase {
         MockClearCacheUseCase()
     }
@@ -478,6 +482,10 @@ final class MockUpdateMaxCacheSizeUseCase: PUpdateMaxCacheSizeUseCase {
 }
 
 final class MockClearCacheUseCase: PClearCacheUseCase {
+    func execute() async throws {}
+}
+
+final class MockApplyCacheSizeLimitUseCase: PApplyCacheSizeLimitUseCase {
     func execute() async throws {}
 }
 

--- a/readeck/UI/Settings/CacheSettingsView.swift
+++ b/readeck/UI/Settings/CacheSettingsView.swift
@@ -7,7 +7,7 @@ struct CacheSettingsView: View {
         Section {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Current Cache Size")
+                    Text("Image Cache")
                     Text("\(viewModel.cacheSize) / \(Int(viewModel.maxCacheSize)) MB max")
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/readeck/UI/readeckApp.swift
+++ b/readeck/UI/readeckApp.swift
@@ -53,6 +53,11 @@ struct readeckApp: App {
                 Task {
                     await loadAppSettings()
                 }
+                Task {
+                    // Enforce the configured image-cache size limit at launch so the
+                    // cache doesn't grow past the maximum across app restarts (Codeberg #44).
+                    try? await DefaultUseCaseFactory.shared.makeSettingsRepository().applyCacheSizeLimit()
+                }
                 appViewModel.bindNetworkStatus(to: appSettings)
             }
             .onReceive(NotificationCenter.default.publisher(for: .settingsChanged)) { _ in

--- a/readeck/UI/readeckApp.swift
+++ b/readeck/UI/readeckApp.swift
@@ -56,7 +56,7 @@ struct readeckApp: App {
                 Task {
                     // Enforce the configured image-cache size limit at launch so the
                     // cache doesn't grow past the maximum across app restarts (Codeberg #44).
-                    try? await DefaultUseCaseFactory.shared.makeSettingsRepository().applyCacheSizeLimit()
+                    try? await DefaultUseCaseFactory.shared.makeApplyCacheSizeLimitUseCase().execute()
                 }
                 appViewModel.bindNetworkStatus(to: appSettings)
             }

--- a/readeckTests/Helpers/TestUseCaseFactory.swift
+++ b/readeckTests/Helpers/TestUseCaseFactory.swift
@@ -53,6 +53,7 @@ class TestUseCaseFactory: UseCaseFactory {
     func makeGetMaxCacheSizeUseCase() -> PGetMaxCacheSizeUseCase { MockGetMaxCacheSizeUseCase() }
     func makeUpdateMaxCacheSizeUseCase() -> PUpdateMaxCacheSizeUseCase { MockUpdateMaxCacheSizeUseCase() }
     func makeClearCacheUseCase() -> PClearCacheUseCase { MockClearCacheUseCase() }
+    func makeApplyCacheSizeLimitUseCase() -> PApplyCacheSizeLimitUseCase { MockApplyCacheSizeLimitUseCase() }
     func makeLoginWithOAuthUseCase() -> PLoginWithOAuthUseCase { MockLoginWithOAuthUseCase() }
     func makeAuthRepository() -> PAuthRepository { MockAuthRepository() }
     func makeSummarizeArticleUseCase() -> PSummarizeArticleUseCase { mockSummarizeArticle }

--- a/readeckTests/UseCases/UpdateUnreadBadgeUseCaseTests.swift
+++ b/readeckTests/UseCases/UpdateUnreadBadgeUseCaseTests.swift
@@ -144,4 +144,5 @@ private final class StubSettingsRepository: PSettingsRepository {
     func getMaxCacheSize() async throws -> UInt { 0 }
     func updateMaxCacheSize(_ sizeInBytes: UInt) async throws {}
     func clearCache() async throws {}
+    func applyCacheSizeLimit() async throws {}
 }


### PR DESCRIPTION
Two things were off with the offline cache:

**The size limit did nothing.** The image cache kept growing way past the max you set (reporter saw 729 MB with a 300 MB limit). Turns out the limit only got applied when you moved the slider — never on launch — and nothing ever cleaned up. Now we apply it on launch, after every sync, and when you change the slider, and Kingfisher trims the cache back down.

**The two size numbers didn't match** because they measure different stuff: Settings shows the image cache, the Debug menu shows the article HTML. Just relabeled them so it's clear — "Image Cache" vs "Article Content".

Fixes Codeberg #44.