### PR TITLE
fix(data): stop swallowing errors with try? in the persistence path (#80)

### DIFF
--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -95,12 +95,18 @@ final class CoreDataManager {
         // Delete the store files
         try FileManager.default.removeItem(at: storeURL)
 
-        // Also delete related files (-wal, -shm)
+        // Also delete related files (-wal, -shm). These may legitimately not
+        // exist (e.g. checkpointed WAL), so only log unexpected removal failures.
         let walURL = storeURL.deletingPathExtension().appendingPathExtension("sqlite-wal")
         let shmURL = storeURL.deletingPathExtension().appendingPathExtension("sqlite-shm")
 
-        try? FileManager.default.removeItem(at: walURL)
-        try? FileManager.default.removeItem(at: shmURL)
+        for auxURL in [walURL, shmURL] where FileManager.default.fileExists(atPath: auxURL.path) {
+            do {
+                try FileManager.default.removeItem(at: auxURL)
+            } catch {
+                logger.warning("Failed to remove Core Data auxiliary file \(auxURL.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
 
         logger.info("Core Data database files deleted successfully")
     }

--- a/readeck/Data/KeychainHelper.swift
+++ b/readeck/Data/KeychainHelper.swift
@@ -48,20 +48,34 @@ final class KeychainHelper {
 
     @discardableResult
     func saveOAuthToken(_ token: OAuthToken) -> Bool {
-        guard let data = try? JSONEncoder().encode(token),
-              let jsonString = String(data: data, encoding: .utf8) else {
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(token)
+        } catch {
+            Logger.auth.error("Failed to encode OAuth token for keychain: \(error.localizedDescription)")
+            return false
+        }
+        guard let jsonString = String(data: data, encoding: .utf8) else {
+            Logger.auth.error("Failed to convert encoded OAuth token to UTF-8 string")
             return false
         }
         return saveString(jsonString, forKey: "readeck_oauth_token")
     }
 
     func loadOAuthToken() -> OAuthToken? {
+        // Empty string is the sentinel written by clearCredentials() on logout,
+        // so treat it as "no token" without attempting (and logging) a decode.
         guard let jsonString = loadString(forKey: "readeck_oauth_token"),
-              let data = jsonString.data(using: .utf8),
-              let token = try? JSONDecoder().decode(OAuthToken.self, from: data) else {
+              !jsonString.isEmpty,
+              let data = jsonString.data(using: .utf8) else {
             return nil
         }
-        return token
+        do {
+            return try JSONDecoder().decode(OAuthToken.self, from: data)
+        } catch {
+            Logger.auth.error("Failed to decode stored OAuth token, user may be signed out unexpectedly: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     @discardableResult
@@ -87,8 +101,15 @@ final class KeychainHelper {
 
     @discardableResult
     func saveCustomHeaders(_ headers: [String: String]) -> Bool {
-        guard let jsonData = try? JSONEncoder().encode(headers),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
+        let jsonData: Data
+        do {
+            jsonData = try JSONEncoder().encode(headers)
+        } catch {
+            Logger.auth.error("Failed to encode custom headers for keychain: \(error.localizedDescription)")
+            return false
+        }
+        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+            Logger.auth.error("Failed to convert encoded custom headers to UTF-8 string")
             return false
         }
         return saveString(jsonString, forKey: "readeck_custom_headers")
@@ -98,11 +119,15 @@ final class KeychainHelper {
     func loadCustomHeaders() -> [String: String]? {
         guard let jsonString = loadString(forKey: "readeck_custom_headers"),
               !jsonString.isEmpty,
-              let jsonData = jsonString.data(using: .utf8),
-              let headers = try? JSONDecoder().decode([String: String].self, from: jsonData) else {
+              let jsonData = jsonString.data(using: .utf8) else {
             return nil
         }
-        return headers
+        do {
+            return try JSONDecoder().decode([String: String].self, from: jsonData)
+        } catch {
+            Logger.auth.error("Failed to decode stored custom headers: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     @discardableResult

--- a/readeck/Data/Repository/LabelsRepository.swift
+++ b/readeck/Data/Repository/LabelsRepository.swift
@@ -19,9 +19,11 @@ final class LabelsRepository: PLabelsRepository, @unchecked Sendable {
             guard let self else { return }
             do {
                 let dtos = try await self.api.getBookmarkLabels()
-                try? await self.saveLabels(dtos)
+                try await self.saveLabels(dtos)
             } catch {
-                // Silent fail - we already have cached data
+                // We already returned cached data, so this only degrades the
+                // background refresh. Log it so a failing labels sync is visible.
+                Logger.data.error("Background labels sync failed: \(error.localizedDescription)")
             }
         }
 

--- a/readeck/Data/Repository/OfflineCacheRepository.swift
+++ b/readeck/Data/Repository/OfflineCacheRepository.swift
@@ -89,7 +89,8 @@ final class OfflineCacheRepository: POfflineCacheRepository {
 
         let context = coreDataManager.context
         return try await context.perform {
-            // First check total bookmarks
+            // First check total bookmarks. This count is purely diagnostic; if it
+            // fails the real fetch below throws, so try? is the right choice here.
             let allRequest: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
             let totalCount = try? context.count(for: allRequest)
             self.logger.info("📊 Total bookmarks in Core Data: \(totalCount ?? 0)")
@@ -182,7 +183,11 @@ final class OfflineCacheRepository: POfflineCacheRepository {
         await withTaskGroup(of: Void.self) { group in
             for url in imageURLsToDelete {
                 group.addTask {
-                    try? await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                    do {
+                        try await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                    } catch {
+                        Logger.sync.warning("Failed to remove cached image \(url.cacheKey): \(error.localizedDescription)")
+                    }
                 }
             }
         }
@@ -241,7 +246,11 @@ final class OfflineCacheRepository: POfflineCacheRepository {
             await withTaskGroup(of: Void.self) { group in
                 for url in imageURLsToDelete {
                     group.addTask {
-                        try? await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                        do {
+                            try await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                        } catch {
+                            Logger.sync.warning("Failed to remove cached image \(url.cacheKey): \(error.localizedDescription)")
+                        }
                     }
                 }
             }
@@ -263,7 +272,8 @@ final class OfflineCacheRepository: POfflineCacheRepository {
             try context.save()
             self.logger.info("💾 Saved bookmark \(bookmark.id) to Core Data with HTML (\(html.utf8.count) bytes)")
 
-            // Verify it was saved
+            // Verify it was saved. The save above already succeeded (or threw), so
+            // this count is only a diagnostic log; try? keeps it non-fatal.
             let verifyRequest: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
             verifyRequest.predicate = NSPredicate(format: "id == %@ AND htmlContent != nil", bookmark.id)
             if let count = try? context.count(for: verifyRequest) {
@@ -549,8 +559,12 @@ final class OfflineCacheRepository: POfflineCacheRepository {
 
         if let image = result {
             // Store with custom key for offline access
-            try? await ImageCache.default.store(image, forKey: cacheKey)
-            logger.info("✅ Cached hero image with key: \(cacheKey)")
+            do {
+                try await ImageCache.default.store(image, forKey: cacheKey)
+                logger.info("✅ Cached hero image with key: \(cacheKey)")
+            } catch {
+                logger.error("Failed to cache hero image with key \(cacheKey): \(error.localizedDescription)")
+            }
         } else {
             logger.warning("❌ Failed to cache hero image for bookmark: \(bookmarkId)")
         }

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -103,10 +103,17 @@ final class SettingsRepository: PSettingsRepository {
                     }
 
                     if let swipeActionConfig = settings.swipeActionConfig {
-                        let encoder = JSONEncoder()
-                        if let jsonData = try? encoder.encode(swipeActionConfig),
-                           let configText = String(data: jsonData, encoding: .utf8) {
-                            existingSettings.swipeActionConfig = configText
+                        do {
+                            let jsonData = try JSONEncoder().encode(swipeActionConfig)
+                            if let configText = String(data: jsonData, encoding: .utf8) {
+                                existingSettings.swipeActionConfig = configText
+                            } else {
+                                Logger.data.error("Failed to convert encoded swipe action config to string")
+                            }
+                        } catch {
+                            // Don't fail the whole settings save just because the
+                            // swipe config couldn't be encoded, but make it visible.
+                            Logger.data.error("Failed to encode swipe action config: \(error.localizedDescription)")
                         }
                     }
                     if let fontSizeNumeric = settings.fontSizeNumeric {
@@ -174,8 +181,13 @@ final class SettingsRepository: PSettingsRepository {
                     // Load swipe action config from JSON
                     var swipeActionConfig: SwipeActionConfig?
                     if let jsonString = settingEntity?.swipeActionConfig,
+                       !jsonString.isEmpty,
                        let jsonData = jsonString.data(using: .utf8) {
-                        swipeActionConfig = try? JSONDecoder().decode(SwipeActionConfig.self, from: jsonData)
+                        do {
+                            swipeActionConfig = try JSONDecoder().decode(SwipeActionConfig.self, from: jsonData)
+                        } catch {
+                            Logger.data.error("Failed to decode stored swipe action config, falling back to default: \(error.localizedDescription)")
+                        }
                     }
 
                     // Load UI preferences from Core Data

--- a/readeck/Data/Service/AppBadgeService.swift
+++ b/readeck/Data/Service/AppBadgeService.swift
@@ -16,7 +16,12 @@ final class AppBadgeService: PAppBadgeService {
     }
 
     func requestAuthorization() async -> Bool {
-        (try? await notificationCenter.requestAuthorization(options: [.badge])) ?? false
+        do {
+            return try await notificationCenter.requestAuthorization(options: [.badge])
+        } catch {
+            Logger.data.error("Failed to request badge authorization: \(error.localizedDescription)")
+            return false
+        }
     }
 
     func setBadgeCount(_ count: Int) async {

--- a/readeck/Data/TokenProvider.swift
+++ b/readeck/Data/TokenProvider.swift
@@ -65,7 +65,9 @@ final class KeychainTokenProvider: TokenProvider {
     }
 
     private func refreshOAuthTokenIfNeeded() async -> OAuthToken? {
-        // If already refreshing, wait for that task to complete
+        // If already refreshing, wait for that task to complete.
+        // The task body catches all errors and returns nil itself, so try? here
+        // only absorbs cancellation, where a nil token is the correct outcome.
         if let existingTask = refreshTask {
             return try? await existingTask.value
         }
@@ -136,6 +138,7 @@ final class KeychainTokenProvider: TokenProvider {
 
         refreshTask = task
         isRefreshing = true
+        // See note above: the task never throws by design; try? only handles cancellation.
         return try? await task.value
     }
 

--- a/readeck/Data/Utils/KingfisherImagePrefetcher.swift
+++ b/readeck/Data/Utils/KingfisherImagePrefetcher.swift
@@ -70,8 +70,12 @@ final class KingfisherImagePrefetcher {
         let image = await downloadImage(from: url)
 
         if let image {
-            try? await ImageCache.default.store(image, forKey: key)
-            Logger.sync.info("✅ Cached image with custom key: \(key)")
+            do {
+                try await ImageCache.default.store(image, forKey: key)
+                Logger.sync.info("✅ Cached image with custom key: \(key)")
+            } catch {
+                Logger.sync.error("Failed to cache image with key \(key): \(error.localizedDescription)")
+            }
         } else {
             Logger.sync.warning("❌ Failed to cache image with key: \(key)")
         }
@@ -87,7 +91,11 @@ final class KingfisherImagePrefetcher {
         await withTaskGroup(of: Void.self) { group in
             for url in urls {
                 group.addTask {
-                    try? await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                    do {
+                        try await KingfisherManager.shared.cache.removeImage(forKey: url.cacheKey)
+                    } catch {
+                        Logger.sync.warning("Failed to remove cached image \(url.cacheKey): \(error.localizedDescription)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #80.

## Problem
~25 `try?` sites in the data layer silently turned failed saves, decodes and cache writes into `nil`. That produced "data gone / sync does nothing" bugs that left no trace in the logs and could not be reproduced.

## Approach
Audited every `try?` in `readeck/Data/**`. Each was classified as either a hidden failure (now logged, and propagated where the caller can react) or a genuine "nil is a valid outcome" case (kept, with a comment explaining why). Logging uses the existing `Logger` infrastructure, which is compiled into both the app and the URLShare extension targets.

## Fixed (errors were being swallowed)
- **KeychainHelper**: log encode/decode failures for the OAuth token and custom headers. `loadOAuthToken` now guards against the empty-string logout sentinel written by `clearCredentials()`, so a normal signed-out state no longer looks like a decode error.
- **LabelsRepository**: propagate `saveLabels` errors into the existing `catch` and log them, instead of dropping the background label sync silently.
- **SettingsRepository**: log encode/decode failures for the swipe action config; skip only that one field rather than losing the whole settings save.
- **OfflineCacheRepository / KingfisherImagePrefetcher**: log image cache store/remove failures instead of discarding them.
- **CoreDataManager**: only attempt to remove `-wal`/`-shm` files that actually exist, and log unexpected removal failures.
- **AppBadgeService**: log badge authorization failures.

## Intentionally kept `try?` (nil is a valid outcome, now documented)
- `TokenProvider` token-refresh task value: the task body catches all errors and returns nil itself, so `try?` only absorbs cancellation.
- Diagnostic Core Data counts in `OfflineCacheRepository` (the real fetch/save right next to them already throws).
- Defensive JSON/regex decoding fallbacks: API error-body parse, `ServerInfoDto` version decoding, HTML image-URL extraction regex.

## Verification
`xcodebuild` succeeds for the `readeck` scheme, including validation and embedding of the `URLShare.appex` extension (confirms both targets compile). SwiftLint build phase passes.

Note: this issue is observability-by-nature. The whole point is that these failures were invisible, so there is no single end-to-end repro; correctness was verified by auditing each code path and confirming a green build across both targets. Unit tests that assert the new logging/propagation behavior belong to the testing group (#82).