### PR TITLE
fix(sync): resilient offline sync with per-item retry and backoff (#79)

### DIFF
--- a/readeck/Data/Repository/OfflineSyncManager.swift
+++ b/readeck/Data/Repository/OfflineSyncManager.swift
@@ -17,9 +17,11 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
     private let coreDataManager = CoreDataManager.shared
     private let api: PAPI
     private let logger = Logger.sync
+    private let retryBackoffBaseSeconds: Double
 
-    init(api: PAPI = API()) {
+    init(api: PAPI = API(), retryBackoffBaseSeconds: Double = 2.0) {
         self.api = api
+        self.retryBackoffBaseSeconds = retryBackoffBaseSeconds
     }
 
     // MARK: - Sync Methods
@@ -45,54 +47,70 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
 
         var successCount = 0
         var failedCount = 0
+        var aborted = false
+        let maxRetries = 2
 
         for bookmark in offlineBookmarks {
             guard let url = bookmark.url else {
+                logger.error("Skipping offline bookmark without URL (id: \(bookmark.id))")
                 failedCount += 1
                 continue
             }
 
             let tags = bookmark.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
             let title = bookmark.title ?? ""
+            let dto = CreateBookmarkRequestDto(url: url, title: title, labels: tags.isEmpty ? nil : tags, html: bookmark.html)
 
-            do {
-                let dto = CreateBookmarkRequestDto(url: url, title: title, labels: tags.isEmpty ? nil : tags, html: bookmark.html)
-                _ = try await api.createBookmark(createRequest: dto)
-
-                deleteOfflineBookmark(bookmark)
-                successCount += 1
-
-                await MainActor.run {
-                    syncStatus = "Synced \(successCount) bookmarks..."
+            var lastError: Error?
+            for attempt in 0...maxRetries {
+                do {
+                    if attempt > 0 {
+                        let delay = Double(attempt) * retryBackoffBaseSeconds // linear backoff, mirrors OfflineCacheSyncUseCase
+                        if delay > 0 {
+                            logger.info("⏳ Retry \(attempt)/\(maxRetries) for \(url) after \(delay)s")
+                            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                        }
+                    }
+                    _ = try await api.createBookmark(createRequest: dto)
+                    deleteOfflineBookmark(bookmark)
+                    successCount += 1
+                    lastError = nil
+                    await MainActor.run { syncStatus = "Synced \(successCount) bookmarks..." }
+                    break
+                } catch {
+                    lastError = error
+                    if !isRetryableError(error) || attempt == maxRetries {
+                        break
+                    }
+                    logger.warning("Temporary error syncing \(url), will retry: \(error.localizedDescription)")
                 }
-            } catch {
-                logger.error("Failed to sync bookmark: \(url) - \(error)")
+            }
+
+            if let lastError {
+                // Keep the entry in the queue (do NOT delete) so it is retried on the next sync.
+                logger.error("Failed to sync bookmark after retries, keeping for later retry: \(url) - \(lastError)")
                 failedCount += 1
 
-                // If first sync attempt fails, server is likely unreachable - abort
-                if successCount == 0 && failedCount == 1 {
-                    await MainActor.run {
-                        isSyncing = false
-                        syncStatus = "Server not reachable. Cannot sync."
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        self.syncStatus = nil
-                    }
-                    return
+                // If the server/network is completely unreachable and nothing has synced yet,
+                // stop early instead of burning backoff delays on every remaining item.
+                // The queue stays intact, so everything is retried on the next sync.
+                if successCount == 0 && isConnectivityError(lastError) {
+                    aborted = true
+                    break
                 }
             }
         }
 
         await MainActor.run {
             isSyncing = false
-            if successCount > 0 {
-                if failedCount == 0 {
-                    syncStatus = "✅ Successfully synced \(successCount) bookmarks"
-                } else {
-                    syncStatus = "⚠️ Synced \(successCount), failed \(failedCount) bookmarks"
-                }
+            if aborted {
+                syncStatus = "Server not reachable. \(failedCount) bookmark(s) kept for later."
+            } else if successCount > 0 {
+                syncStatus = failedCount == 0
+                    ? "✅ Successfully synced \(successCount) bookmarks"
+                    : "⚠️ Synced \(successCount), \(failedCount) kept for retry"
             } else if failedCount > 0 {
-                syncStatus = "❌ Sync failed - check your connection"
+                syncStatus = "❌ Sync failed - \(failedCount) bookmark(s) kept for retry"
             }
         }
 
@@ -125,6 +143,46 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
             }
         } catch {
             logger.error("Failed to delete offline bookmark: \(error)")
+        }
+    }
+
+    // MARK: - Retry Helpers
+
+    // Mirrors OfflineCacheSyncUseCase.isRetryableError, but does NOT treat HTTP 400
+    // as retryable (400 is a permanent client error; the mirrored version has that bug).
+    private func isRetryableError(_ error: Error) -> Bool {
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .serverError(let statusCode):
+                return statusCode == 502 || statusCode == 503 || statusCode == 504
+            case .serverErrorWithMessage(let statusCode, _):
+                return statusCode == 502 || statusCode == 503 || statusCode == 504
+            case .invalidURL, .invalidResponse:
+                return false
+            }
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut, .networkConnectionLost, .cannotConnectToHost,
+                 .notConnectedToInternet, .cannotFindHost, .dnsLookupFailed:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
+    }
+
+    // True only for "server/network completely unreachable" conditions, used to stop
+    // the whole run early when nothing has synced yet (vs. a single bad item).
+    private func isConnectivityError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .notConnectedToInternet, .cannotConnectToHost, .cannotFindHost,
+             .networkConnectionLost, .dnsLookupFailed, .dataNotAllowed:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/readeck/Data/Repository/OfflineSyncManager.swift
+++ b/readeck/Data/Repository/OfflineSyncManager.swift
@@ -51,8 +51,7 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
         let maxRetries = 2
 
         for bookmark in offlineBookmarks {
-            // Read managed-object properties on the context's queue, never from this
-            // nonisolated async context (viewContext entities are not thread-safe).
+            // Read entity properties on the context queue (not thread-safe otherwise).
             var snapshot: (url: String, title: String, tags: [String], html: String?)?
             bookmark.managedObjectContext?.performAndWait {
                 guard let url = bookmark.url else { return }
@@ -105,9 +104,7 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
                 logger.error("Failed to sync bookmark after retries, keeping for later retry: \(url) - \(lastError)")
                 failedCount += 1
 
-                // If the server/network is completely unreachable and nothing has synced yet,
-                // stop early instead of burning backoff delays on every remaining item.
-                // The queue stays intact, so everything is retried on the next sync.
+                // Fully offline and nothing synced yet: stop early, queue stays intact.
                 if successCount == 0 && isConnectivityError(lastError) {
                     aborted = true
                     break
@@ -162,8 +159,7 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
 
     // MARK: - Retry Helpers
 
-    // Mirrors OfflineCacheSyncUseCase.isRetryableError, but does NOT treat HTTP 400
-    // as retryable (400 is a permanent client error; the mirrored version has that bug).
+    // Retry only transient server/network errors (400 stays permanent, unlike OfflineCacheSyncUseCase).
     private func isRetryableError(_ error: Error) -> Bool {
         if let apiError = error as? APIError {
             switch apiError {
@@ -187,8 +183,7 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
         return false
     }
 
-    // True only for "server/network completely unreachable" conditions, used to stop
-    // the whole run early when nothing has synced yet (vs. a single bad item).
+    // True only when the server/network is completely unreachable (vs. a single bad item).
     private func isConnectivityError(_ error: Error) -> Bool {
         guard let urlError = error as? URLError else { return false }
         switch urlError.code {

--- a/readeck/Data/Repository/OfflineSyncManager.swift
+++ b/readeck/Data/Repository/OfflineSyncManager.swift
@@ -51,15 +51,29 @@ open class OfflineSyncManager: ObservableObject, @unchecked Sendable {
         let maxRetries = 2
 
         for bookmark in offlineBookmarks {
-            guard let url = bookmark.url else {
-                logger.error("Skipping offline bookmark without URL (id: \(bookmark.id))")
+            // Read managed-object properties on the context's queue, never from this
+            // nonisolated async context (viewContext entities are not thread-safe).
+            var snapshot: (url: String, title: String, tags: [String], html: String?)?
+            bookmark.managedObjectContext?.performAndWait {
+                guard let url = bookmark.url else { return }
+                let tags = bookmark.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
+                snapshot = (url, bookmark.title ?? "", tags, bookmark.html)
+            }
+
+            guard let snapshot else {
+                // objectID is thread-safe; the String `id` attribute is not.
+                logger.error("Skipping offline bookmark without URL (id: \(bookmark.objectID))")
                 failedCount += 1
                 continue
             }
 
-            let tags = bookmark.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
-            let title = bookmark.title ?? ""
-            let dto = CreateBookmarkRequestDto(url: url, title: title, labels: tags.isEmpty ? nil : tags, html: bookmark.html)
+            let url = snapshot.url
+            let dto = CreateBookmarkRequestDto(
+                url: snapshot.url,
+                title: snapshot.title,
+                labels: snapshot.tags.isEmpty ? nil : snapshot.tags,
+                html: snapshot.html
+            )
 
             var lastError: Error?
             for attempt in 0...maxRetries {

--- a/readeckTests/Helpers/TestMocks.swift
+++ b/readeckTests/Helpers/TestMocks.swift
@@ -166,9 +166,9 @@ class TestCoreDataManager {
 class TestableOfflineSyncManager: OfflineSyncManager {
     let mockCoreDataManager: TestCoreDataManager
 
-    init(api: PAPI, coreDataManager: TestCoreDataManager) {
+    init(api: PAPI, coreDataManager: TestCoreDataManager, retryBackoffBaseSeconds: Double = 0) {
         self.mockCoreDataManager = coreDataManager
-        super.init(api: api)
+        super.init(api: api, retryBackoffBaseSeconds: retryBackoffBaseSeconds)
     }
 
     override func getOfflineBookmarks() -> [ArticleURLEntity] {

--- a/readeckTests/OfflineSyncManagerTests.swift
+++ b/readeckTests/OfflineSyncManagerTests.swift
@@ -47,51 +47,118 @@ struct OfflineSyncManagerTests {
         #expect(mockCoreData.fetchAllBookmarks().isEmpty)
     }
 
-    // MARK: - Test: Server Unreachable
+    // MARK: - Test: One Bad Item Does Not Block The Rest
 
-    @Test("Should abort on first failure (server unreachable)")
-    func testServerUnreachable() async throws {
+    @Test("A single permanently failing item does not abort the rest")
+    func testOneBadItemDoesNotBlockRest() async throws {
         let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
 
-        _ = mockCoreData.createTestBookmark(url: "https://example.com/1", title: "Article 1")
-        _ = mockCoreData.createTestBookmark(url: "https://example.com/2", title: "Article 2")
-        _ = mockCoreData.createTestBookmark(url: "https://example.com/3", title: "Article 3")
-
-        mockAPI.createBookmarkResults = [.failure(APIError.serverError(503))]
-
-        await syncManager.syncOfflineBookmarks()
-        try await Task.sleep(for: .milliseconds(100))
-
-        #expect(syncManager.isSyncing == false)
-        #expect(syncManager.syncStatus == "Server not reachable. Cannot sync.")
-        #expect(mockAPI.createBookmarkCalls.count == 1)
-        #expect(mockCoreData.fetchAllBookmarks().count == 3)
-    }
-
-    // MARK: - Test: Partial Success
-
-    @Test("Should handle partial sync success")
-    func testPartialSuccess() async throws {
-        let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
-
-        for i in 1...4 {
+        for i in 1...3 {
             _ = mockCoreData.createTestBookmark(url: "https://example.com/\(i)", title: "Article \(i)")
         }
 
+        // First call is a permanent (non-retryable) 400, the rest succeed.
+        // fetchAllBookmarks is unsorted, so exactly one item fails regardless of order.
         mockAPI.createBookmarkResults = [
-            .success(mockSuccessResponse()),
             .failure(APIError.serverError(400)),
             .success(mockSuccessResponse()),
-            .failure(APIError.serverError(400))
+            .success(mockSuccessResponse())
         ]
 
         await syncManager.syncOfflineBookmarks()
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(syncManager.isSyncing == false)
-        #expect(syncManager.syncStatus?.contains("Synced 2, failed 2") == true)
-        #expect(mockAPI.createBookmarkCalls.count == 4)
-        #expect(mockCoreData.fetchAllBookmarks().count == 2)
+        // All 3 items attempted (no retry on the 400), 2 succeeded, 1 kept.
+        #expect(mockAPI.createBookmarkCalls.count == 3)
+        #expect(mockCoreData.fetchAllBookmarks().count == 1)
+        #expect(syncManager.syncStatus?.contains("Synced 2, 1 kept for retry") == true)
+    }
+
+    // MARK: - Test: Retry On Transient Error Then Success
+
+    @Test("Retries a transient error and then succeeds")
+    func testRetryTransientThenSuccess() async throws {
+        let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
+
+        _ = mockCoreData.createTestBookmark(url: "https://example.com/1", title: "Article 1")
+
+        mockAPI.createBookmarkResults = [
+            .failure(APIError.serverError(503)),
+            .success(mockSuccessResponse())
+        ]
+
+        await syncManager.syncOfflineBookmarks()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(syncManager.isSyncing == false)
+        #expect(mockAPI.createBookmarkCalls.count == 2)
+        #expect(mockCoreData.fetchAllBookmarks().isEmpty)
+        #expect(syncManager.syncStatus?.contains("Successfully synced 1") == true)
+    }
+
+    // MARK: - Test: Permanent Error Is Not Retried
+
+    @Test("A permanent error is not retried and the item is kept")
+    func testPermanentErrorNotRetried() async throws {
+        let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
+
+        _ = mockCoreData.createTestBookmark(url: "https://example.com/1", title: "Article 1")
+
+        mockAPI.createBookmarkResults = [.failure(APIError.serverError(400))]
+
+        await syncManager.syncOfflineBookmarks()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(syncManager.isSyncing == false)
+        #expect(mockAPI.createBookmarkCalls.count == 1)
+        #expect(mockCoreData.fetchAllBookmarks().count == 1)
+    }
+
+    // MARK: - Test: Exhausted Retries Keep Item In Queue
+
+    @Test("Exhausted retries keep the item in the queue")
+    func testExhaustedRetriesKeepItem() async throws {
+        let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
+
+        _ = mockCoreData.createTestBookmark(url: "https://example.com/1", title: "Article 1")
+
+        mockAPI.createBookmarkResults = Array(repeating: .failure(APIError.serverError(503)), count: 3)
+
+        await syncManager.syncOfflineBookmarks()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(syncManager.isSyncing == false)
+        // 1 initial attempt + 2 retries.
+        #expect(mockAPI.createBookmarkCalls.count == 3)
+        #expect(mockCoreData.fetchAllBookmarks().count == 1)
+    }
+
+    // MARK: - Test: Connectivity Error Stops Early, Queue Intact
+
+    @Test("Connectivity error on the first item stops early and keeps the whole queue")
+    func testConnectivityErrorStopsEarly() async throws {
+        let (syncManager, mockAPI, mockCoreData) = createTestEnvironment()
+
+        for i in 1...3 {
+            _ = mockCoreData.createTestBookmark(url: "https://example.com/\(i)", title: "Article \(i)")
+        }
+
+        // notConnectedToInternet is retryable AND a connectivity error, so the first
+        // item is attempted 3 times (1 + 2 retries), then the whole run aborts.
+        mockAPI.createBookmarkResults = Array(
+            repeating: .failure(URLError(.notConnectedToInternet)),
+            count: 3
+        )
+
+        await syncManager.syncOfflineBookmarks()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(syncManager.isSyncing == false)
+        // Only the first item was touched (with retries); the other 2 were not attempted.
+        #expect(mockAPI.createBookmarkCalls.count == 3)
+        #expect(mockCoreData.fetchAllBookmarks().count == 3)
+        #expect(syncManager.syncStatus?.hasPrefix("Server not reachable") == true)
     }
 
     // MARK: - Test: Bookmark Without URL
@@ -155,7 +222,7 @@ struct OfflineSyncManagerTests {
     private func createTestEnvironment() -> (TestableOfflineSyncManager, TestMockAPI, TestCoreDataManager) {
         let mockAPI = TestMockAPI()
         let mockCoreData = TestCoreDataManager()
-        let syncManager = TestableOfflineSyncManager(api: mockAPI, coreDataManager: mockCoreData)
+        let syncManager = TestableOfflineSyncManager(api: mockAPI, coreDataManager: mockCoreData, retryBackoffBaseSeconds: 0)
         return (syncManager, mockAPI, mockCoreData)
     }
 


### PR DESCRIPTION
Closes #79.

`OfflineSyncManager` aborted the whole queue on the first failing bookmark, with no retry - one bad entry blocked everything.

- Per-item failure isolation: a failing bookmark no longer aborts the rest.
- Retry up to 2× with linear backoff (mirrors `OfflineCacheSyncUseCase`), only for transient errors (502/503/504, network timeouts). 400 stays permanent (the mirrored version has that as a bug).
- Failed items stay in the queue (only successes are deleted) and are retried on the next sync.
- Early-exit only on genuine connectivity errors while nothing has synced yet, so a fully offline server doesn't burn backoff on every item. Queue stays intact.
- Backoff base delay injectable via init (default 2s, tests use 0).
- Follow-up commit: entity fields are snapshotted inside `performAndWait` before use, so no viewContext managed object is read off its queue (complements #81).

Tests (Swift Testing): item isolation, retry-then-success, permanent-not-retried, exhausted-retries-kept, connectivity-stops-early, plus existing happy-path/empty/no-URL/tags. 10/10 green.