### PR TITLE
fix(coredata): harden threading with performAndWait context boundaries (#81)

### DIFF
--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -65,9 +65,7 @@ final class CoreDataManager {
     }
 
     func save() {
-        // Wrap the whole body in performAndWait so the viewContext is never
-        // touched without its queue. performAndWait is safe from any thread
-        // (it dispatches onto the main queue and is reentrant).
+        // performAndWait keeps the viewContext on its queue; safe from any thread.
         context.performAndWait {
             guard context.hasChanges else { return }
             do {

--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -60,6 +60,8 @@ final class CoreDataManager {
     func newBackgroundContext() -> NSManagedObjectContext {
         let context = persistentContainer.newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
+        // Match the viewContext's policy so conflicts resolve consistently;
+        // the default (NSErrorMergePolicy) would fail the save on a conflict.
         context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         return context
     }

--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -57,18 +57,19 @@ final class CoreDataManager {
         persistentContainer.viewContext
     }
 
-    var mainContext: NSManagedObjectContext {
-        persistentContainer.viewContext
-    }
-
     func newBackgroundContext() -> NSManagedObjectContext {
         let context = persistentContainer.newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         return context
     }
 
     func save() {
-        if context.hasChanges {
+        // Wrap the whole body in performAndWait so the viewContext is never
+        // touched without its queue. performAndWait is safe from any thread
+        // (it dispatches onto the main queue and is reentrant).
+        context.performAndWait {
+            guard context.hasChanges else { return }
             do {
                 try context.save()
                 logger.debug("Core Data context saved successfully")

--- a/readeck/Data/Repository/OfflineCacheRepository.swift
+++ b/readeck/Data/Repository/OfflineCacheRepository.swift
@@ -62,20 +62,29 @@ final class OfflineCacheRepository: POfflineCacheRepository {
         fetchRequest.predicate = NSPredicate(format: "id == %@ AND htmlContent != nil", id)
         fetchRequest.fetchLimit = 1
 
-        do {
-            let results = try coreDataManager.context.fetch(fetchRequest)
-            if let entity = results.first {
-                // Update last access date
-                entity.lastAccessDate = Date()
-                coreDataManager.save()
-                logger.debug("Retrieved cached article for bookmark \(id)")
-                return entity.htmlContent
+        // Fetch, update last access date and save inside a single performAndWait
+        // block so the viewContext is only touched on its queue. Only the value
+        // type (String?) escapes the block, never the managed object.
+        let context = coreDataManager.context
+        var html: String?
+        context.performAndWait {
+            do {
+                let results = try context.fetch(fetchRequest)
+                if let entity = results.first {
+                    // Update last access date
+                    entity.lastAccessDate = Date()
+                    if context.hasChanges {
+                        try context.save()
+                    }
+                    logger.debug("Retrieved cached article for bookmark \(id)")
+                    html = entity.htmlContent
+                }
+            } catch {
+                logger.error("Error fetching cached article: \(error.localizedDescription)")
             }
-        } catch {
-            logger.error("Error fetching cached article: \(error.localizedDescription)")
         }
 
-        return nil
+        return html
     }
 
     func hasCachedArticle(id: String) -> Bool {
@@ -117,26 +126,41 @@ final class OfflineCacheRepository: POfflineCacheRepository {
         let fetchRequest: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "htmlContent != nil")
 
-        do {
-            return try coreDataManager.context.count(for: fetchRequest)
-        } catch {
-            logger.error("Error counting cached articles: \(error.localizedDescription)")
-            return 0
+        // Count on the context's queue; only the Int result escapes the block.
+        let context = coreDataManager.context
+        var count = 0
+        context.performAndWait {
+            do {
+                count = try context.count(for: fetchRequest)
+            } catch {
+                logger.error("Error counting cached articles: \(error.localizedDescription)")
+            }
         }
+        return count
     }
 
     func getCacheSize() -> String {
         let fetchRequest: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "htmlContent != nil")
 
-        do {
-            let entities = try coreDataManager.context.fetch(fetchRequest)
-            let totalBytes = entities.reduce(0) { $0 + $1.cacheSize }
-            return ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
-        } catch {
-            logger.error("Error calculating cache size: \(error.localizedDescription)")
+        // Fetch and reduce on the context's queue; only value types escape the
+        // block, never the managed objects themselves.
+        let context = coreDataManager.context
+        var totalBytes: Int64 = 0
+        var failed = false
+        context.performAndWait {
+            do {
+                let entities = try context.fetch(fetchRequest)
+                totalBytes = entities.reduce(0) { $0 + $1.cacheSize }
+            } catch {
+                logger.error("Error calculating cache size: \(error.localizedDescription)")
+                failed = true
+            }
+        }
+        if failed {
             return "0 KB"
         }
+        return ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
     }
 
     // MARK: - Cache Management

--- a/readeck/Data/Repository/OfflineCacheRepository.swift
+++ b/readeck/Data/Repository/OfflineCacheRepository.swift
@@ -62,9 +62,7 @@ final class OfflineCacheRepository: POfflineCacheRepository {
         fetchRequest.predicate = NSPredicate(format: "id == %@ AND htmlContent != nil", id)
         fetchRequest.fetchLimit = 1
 
-        // Fetch, update last access date and save inside a single performAndWait
-        // block so the viewContext is only touched on its queue. Only the value
-        // type (String?) escapes the block, never the managed object.
+        // Keep viewContext access on its queue; only the String? escapes.
         let context = coreDataManager.context
         var html: String?
         context.performAndWait {
@@ -143,8 +141,7 @@ final class OfflineCacheRepository: POfflineCacheRepository {
         let fetchRequest: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "htmlContent != nil")
 
-        // Fetch and reduce on the context's queue; only value types escape the
-        // block, never the managed objects themselves.
+        // Fetch and reduce on the context's queue; only value types escape.
         let context = coreDataManager.context
         var totalBytes: Int64 = 0
         var failed = false

--- a/readeckTests/CoreDataThreadingTests.swift
+++ b/readeckTests/CoreDataThreadingTests.swift
@@ -4,16 +4,8 @@
 //
 //  Created by Ilyas Hallak on 21.08.26.
 //
-//  Verifies the CoreData threading patterns hardened in issue #81:
-//  - Concurrent writes from multiple background contexts plus concurrent
-//    reads on the main context must not crash and must stay consistent.
-//  - A performAndWait-wrapped save on the main context persists and is
-//    visible via a subsequent fetch.
-//
-//  These tests exercise the threading *patterns* on an isolated in-memory
-//  stack (same approach as the existing OfflineCacheRepository tests),
-//  because CoreDataManager.shared is a singleton bound to the App Group
-//  store and is not cleanly isolatable in the test target.
+//  Verifies the issue #81 CoreData threading patterns on an isolated in-memory
+//  stack (CoreDataManager.shared is a singleton bound to the App Group store).
 //
 
 import Testing
@@ -26,9 +18,7 @@ struct CoreDataThreadingTests {
 
     // MARK: - Test Setup
 
-    /// Builds an in-memory persistent container that mirrors CoreDataManager's
-    /// configuration (automatic parent merging + property-object-trump policy),
-    /// so background contexts and the view context share one coordinator.
+    /// In-memory container mirroring CoreDataManager's merge configuration.
     private func makeContainer() -> NSPersistentContainer {
         let model = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
         let container = NSPersistentContainer(name: "readeck", managedObjectModel: model)
@@ -153,9 +143,7 @@ struct CoreDataThreadingTests {
         let container = makeContainer()
         let viewContext = container.viewContext
 
-        // performAndWait is documented as reentrant; nesting it on the same
-        // queue must not deadlock. This mirrors calling save() from within a
-        // block that already runs on the context queue.
+        // performAndWait is reentrant; nesting on the same queue must not deadlock.
         var count = -1
         viewContext.performAndWait {
             makeBookmarkEntity(in: viewContext, id: "nested-1")

--- a/readeckTests/CoreDataThreadingTests.swift
+++ b/readeckTests/CoreDataThreadingTests.swift
@@ -1,0 +1,171 @@
+//
+//  CoreDataThreadingTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak on 21.08.26.
+//
+//  Verifies the CoreData threading patterns hardened in issue #81:
+//  - Concurrent writes from multiple background contexts plus concurrent
+//    reads on the main context must not crash and must stay consistent.
+//  - A performAndWait-wrapped save on the main context persists and is
+//    visible via a subsequent fetch.
+//
+//  These tests exercise the threading *patterns* on an isolated in-memory
+//  stack (same approach as the existing OfflineCacheRepository tests),
+//  because CoreDataManager.shared is a singleton bound to the App Group
+//  store and is not cleanly isolatable in the test target.
+//
+
+import Testing
+import Foundation
+import CoreData
+@testable import readeck
+
+@Suite("CoreData Threading Tests")
+struct CoreDataThreadingTests {
+
+    // MARK: - Test Setup
+
+    /// Builds an in-memory persistent container that mirrors CoreDataManager's
+    /// configuration (automatic parent merging + property-object-trump policy),
+    /// so background contexts and the view context share one coordinator.
+    private func makeContainer() -> NSPersistentContainer {
+        let model = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
+        let container = NSPersistentContainer(name: "readeck", managedObjectModel: model)
+
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+
+        var loadError: Error?
+        container.loadPersistentStores { _, error in
+            loadError = error
+        }
+        #expect(loadError == nil)
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return container
+    }
+
+    /// Mirrors CoreDataManager.newBackgroundContext().
+    private func makeBackgroundContext(_ container: NSPersistentContainer) -> NSManagedObjectContext {
+        let context = container.newBackgroundContext()
+        context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return context
+    }
+
+    private func makeBookmarkEntity(in context: NSManagedObjectContext, id: String) {
+        let entity = BookmarkEntity(context: context)
+        entity.id = id
+        entity.title = "Article \(id)"
+        entity.htmlContent = "<html><body>\(id)</body></html>"
+        entity.cachedDate = Date()
+        entity.lastAccessDate = Date()
+        entity.cacheSize = Int64(id.utf8.count)
+    }
+
+    private func totalCount(in context: NSManagedObjectContext) -> Int {
+        var count = 0
+        context.performAndWait {
+            let request: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
+            count = (try? context.count(for: request)) ?? 0
+        }
+        return count
+    }
+
+    // MARK: - Tests
+
+    @Test("Concurrent background writes and main-context reads stay consistent")
+    func testConcurrentWritesAndReads() async {
+        let container = makeContainer()
+        let viewContext = container.viewContext
+
+        let writerCount = 8
+        let recordsPerWriter = 25
+
+        await withTaskGroup(of: Void.self) { group in
+            // Writers: each on its own background context.
+            for writer in 0..<writerCount {
+                group.addTask {
+                    let context = self.makeBackgroundContext(container)
+                    context.performAndWait {
+                        for record in 0..<recordsPerWriter {
+                            self.makeBookmarkEntity(in: context, id: "w\(writer)-r\(record)")
+                        }
+                        try? context.save()
+                    }
+                }
+            }
+
+            // Concurrent readers on the main context. These must not crash
+            // while writers merge changes into the view context.
+            for _ in 0..<writerCount {
+                group.addTask {
+                    for _ in 0..<10 {
+                        _ = self.totalCount(in: viewContext)
+                    }
+                }
+            }
+        }
+
+        // All records must be present and unique once every writer has saved.
+        let expected = writerCount * recordsPerWriter
+        #expect(totalCount(in: viewContext) == expected)
+
+        var uniqueIDs = Set<String>()
+        viewContext.performAndWait {
+            let request: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
+            let entities = (try? viewContext.fetch(request)) ?? []
+            uniqueIDs = Set(entities.compactMap { $0.id })
+        }
+        #expect(uniqueIDs.count == expected)
+    }
+
+    @Test("performAndWait-wrapped save persists and is visible via fetch")
+    func testPerformAndWaitSavePersists() {
+        let container = makeContainer()
+        let viewContext = container.viewContext
+
+        // Write inside performAndWait, exactly like CoreDataManager.save().
+        viewContext.performAndWait {
+            makeBookmarkEntity(in: viewContext, id: "persist-1")
+            guard viewContext.hasChanges else { return }
+            try? viewContext.save()
+        }
+
+        // A fresh background context reading the same store must see the record.
+        let readContext = makeBackgroundContext(container)
+        var found: String?
+        readContext.performAndWait {
+            let request: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", "persist-1")
+            request.fetchLimit = 1
+            found = (try? readContext.fetch(request))?.first?.htmlContent
+        }
+
+        #expect(found == "<html><body>persist-1</body></html>")
+    }
+
+    @Test("performAndWait is reentrant and safe when nested")
+    func testNestedPerformAndWaitIsSafe() {
+        let container = makeContainer()
+        let viewContext = container.viewContext
+
+        // performAndWait is documented as reentrant; nesting it on the same
+        // queue must not deadlock. This mirrors calling save() from within a
+        // block that already runs on the context queue.
+        var count = -1
+        viewContext.performAndWait {
+            makeBookmarkEntity(in: viewContext, id: "nested-1")
+            viewContext.performAndWait {
+                try? viewContext.save()
+            }
+            let request: NSFetchRequest<BookmarkEntity> = BookmarkEntity.fetchRequest()
+            count = (try? viewContext.count(for: request)) ?? -1
+        }
+
+        #expect(count == 1)
+    }
+}


### PR DESCRIPTION
Closes #81.

`CoreDataManager` touched the viewContext without queue protection and `OfflineCacheRepository` read it nakedly from 3 sync methods - classic CoreData race risk.

Minimal-invasive fix (no `@MainActor`, no signature changes, extension untouched): wrap viewContext access in `performAndWait` (safe from any thread, reentrant).

- `save()` wrapped in `performAndWait`
- `newBackgroundContext()`: explicit `mergePolicy` (was defaulting to `NSErrorMergePolicy`)
- `getCachedArticle`/`getCachedArticlesCount`/`getCacheSize`: fetch/count/save inside `performAndWait`, only value types escape
- removed unused `mainContext` alias

Tests: new `CoreDataThreadingTests` (concurrent writes + reads, persistence, reentrancy). All green; Thread Sanitizer run over the CoreData suites reports no data races.