### PR TITLE
feat(network): injectable URLSession with configured timeouts

### DIFF
--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -30,10 +30,15 @@ protocol PAPI {
 
 final class API: PAPI {
     let tokenProvider: TokenProvider
+    private let session: HTTPSession
     private let logger = Logger.network
 
-    init(tokenProvider: TokenProvider = KeychainTokenProvider()) {
+    init(
+        tokenProvider: TokenProvider = KeychainTokenProvider(),
+        session: HTTPSession = HTTPSessionFactory.makeDefault()
+    ) {
         self.tokenProvider = tokenProvider
+        self.session = session
     }
 
     private var baseURL: String {
@@ -113,7 +118,7 @@ final class API: PAPI {
             useBaseURL: true
         )
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -142,7 +147,7 @@ final class API: PAPI {
             useBaseURL: true
         )
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -182,7 +187,7 @@ final class API: PAPI {
             request.timeoutInterval = timeoutInterval
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for \(endpoint)")
@@ -226,7 +231,7 @@ final class API: PAPI {
 
         logger.logNetworkRequest(method: "POST", url: loginEndpoint)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for login request")
@@ -441,7 +446,7 @@ final class API: PAPI {
         )
         request.timeoutInterval = timeout
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for \(endpoint)")
@@ -483,7 +488,7 @@ final class API: PAPI {
         let fullURL = "\(baseURL)\(endpoint)"
         logger.logNetworkRequest(method: "POST", url: fullURL)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for sync article fallback")
@@ -542,7 +547,7 @@ final class API: PAPI {
         let fullURL = "\(baseURL)\(endpoint)"
         logger.logNetworkRequest(method: "PATCH", url: fullURL)
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for PATCH \(fullURL)")
@@ -575,7 +580,7 @@ final class API: PAPI {
         let fullURL = "\(baseURL)\(endpoint)"
         logger.logNetworkRequest(method: "DELETE", url: fullURL)
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for DELETE \(fullURL)")
@@ -690,7 +695,7 @@ final class API: PAPI {
         let fullURL = "\(baseURL)\(endpoint)"
         logger.logNetworkRequest(method: "DELETE", url: fullURL)
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for DELETE \(fullURL)")
@@ -728,7 +733,7 @@ final class API: PAPI {
 
         logger.logNetworkRequest(method: "POST", url: url.absoluteString)
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let (data, response) = try await session.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for OAuth client registration")
@@ -792,7 +797,7 @@ final class API: PAPI {
 
         logger.logNetworkRequest(method: "POST", url: url.absoluteString)
 
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let (data, response) = try await session.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for OAuth token \(isRefresh ? "refresh" : "exchange")")
@@ -819,7 +824,7 @@ enum HTTPMethod: String {
     case DELETE
 }
 
-enum APIError: Error {
+enum APIError: Error, Equatable {
     case invalidURL
     case invalidResponse
     case serverError(Int)

--- a/readeck/Data/API/HTTPSession.swift
+++ b/readeck/Data/API/HTTPSession.swift
@@ -1,0 +1,33 @@
+//
+//  HTTPSession.swift
+//  readeck
+//
+//  Created by Ilyas Hallak
+//
+
+import Foundation
+
+/// Schmale Abstraktion über die eine URLSession-Methode, die die App tatsächlich nutzt.
+/// `URLSession` erfüllt die Signatur bereits nativ, dadurch bleibt die Extension leer.
+/// In Tests lässt sich ein einfacher Mock injizieren, ohne URLProtocol-Setup.
+protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {}
+
+enum HTTPSessionFactory {
+    /// Default-Session mit konfigurierten Timeouts für self-hosted / langsame Server.
+    /// Der 60s-Default fühlt sich sonst wie ein Freeze an.
+    ///
+    /// `waitsForConnectivity` bleibt bewusst aus: OfflineSyncManager erkennt einen
+    /// nicht erreichbaren Server an URLError-Codes wie `.notConnectedToInternet` und
+    /// bricht den Sync dann früh ab. Mit Warten käme stattdessen erst nach
+    /// `timeoutIntervalForResource` ein `.timedOut`, und die Offline-Erkennung liefe ins Leere.
+    static func makeDefault() -> HTTPSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 120
+        return URLSession(configuration: configuration)
+    }
+}

--- a/readeck/Data/API/InfoApiClient.swift
+++ b/readeck/Data/API/InfoApiClient.swift
@@ -12,10 +12,15 @@ protocol PInfoApiClient {
 
 final class InfoApiClient: PInfoApiClient {
     private let tokenProvider: TokenProvider
+    private let session: HTTPSession
     private let logger = Logger.network
 
-    init(tokenProvider: TokenProvider = KeychainTokenProvider()) {
+    init(
+        tokenProvider: TokenProvider = KeychainTokenProvider(),
+        session: HTTPSession = HTTPSessionFactory.makeDefault()
+    ) {
         self.tokenProvider = tokenProvider
+        self.session = session
     }
 
     func getServerInfo(endpoint: String? = nil) async throws -> ServerInfoDto {
@@ -27,7 +32,7 @@ final class InfoApiClient: PInfoApiClient {
 
         logger.logNetworkRequest(method: "GET", url: url.absoluteString)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for server info")

--- a/readeck/Data/API/ProfileApiClient.swift
+++ b/readeck/Data/API/ProfileApiClient.swift
@@ -13,10 +13,15 @@ protocol PProfileApiClient {
 
 final class ProfileApiClient: PProfileApiClient {
     private let tokenProvider: TokenProvider
+    private let session: HTTPSession
     private let logger = Logger.network
 
-    init(tokenProvider: TokenProvider = KeychainTokenProvider()) {
+    init(
+        tokenProvider: TokenProvider = KeychainTokenProvider(),
+        session: HTTPSession = HTTPSessionFactory.makeDefault()
+    ) {
         self.tokenProvider = tokenProvider
+        self.session = session
     }
 
     func getProfile() async throws -> UserProfileDto {
@@ -26,7 +31,7 @@ final class ProfileApiClient: PProfileApiClient {
 
         logger.logNetworkRequest(method: "GET", url: url.absoluteString)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.error("Invalid HTTP response for user profile")

--- a/readeck/Data/TokenProvider.swift
+++ b/readeck/Data/TokenProvider.swift
@@ -18,7 +18,12 @@ protocol TokenProvider {
 
 final class KeychainTokenProvider: TokenProvider {
     private let keychainHelper = KeychainHelper.shared
+    private let session: HTTPSession
     private let logger = Logger.network
+
+    init(session: HTTPSession = HTTPSessionFactory.makeDefault()) {
+        self.session = session
+    }
 
     // Cache to avoid repeated keychain access
     private var cachedToken: String?
@@ -115,7 +120,7 @@ final class KeychainTokenProvider: TokenProvider {
                 urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
                 urlRequest.httpBody = formBody.data(using: .utf8)
 
-                let (data, response) = try await URLSession.shared.data(for: urlRequest)
+                let (data, response) = try await session.data(for: urlRequest)
 
                 guard let httpResponse = response as? HTTPURLResponse,
                       200...299 ~= httpResponse.statusCode else {

--- a/readeck/UI/Factory/DefaultUseCaseFactory.swift
+++ b/readeck/UI/Factory/DefaultUseCaseFactory.swift
@@ -44,14 +44,16 @@ protocol UseCaseFactory {
 }
 
 final class DefaultUseCaseFactory: UseCaseFactory {
-    private let tokenProvider = KeychainTokenProvider()
-    private lazy var api: PAPI = API(tokenProvider: tokenProvider)
-    private lazy var profileApiClient: PProfileApiClient = ProfileApiClient(tokenProvider: tokenProvider)
+    // Eine geteilte, mit Timeouts konfigurierte Session für die ganze App.
+    private let httpSession: HTTPSession = HTTPSessionFactory.makeDefault()
+    private lazy var tokenProvider = KeychainTokenProvider(session: httpSession)
+    private lazy var api: PAPI = API(tokenProvider: tokenProvider, session: httpSession)
+    private lazy var profileApiClient: PProfileApiClient = ProfileApiClient(tokenProvider: tokenProvider, session: httpSession)
     private lazy var getUserProfileUseCase: PGetUserProfileUseCase = GetUserProfileUseCase(profileApiClient: profileApiClient)
     private lazy var authRepository: PAuthRepository = AuthRepository(api: api, settingsRepository: settingsRepository, getUserProfileUseCase: getUserProfileUseCase)
     private lazy var bookmarksRepository: PBookmarksRepository = BookmarksRepository(api: api)
     private lazy var settingsRepository: PSettingsRepository = SettingsRepository(tokenProvider: tokenProvider)
-    private lazy var infoApiClient: PInfoApiClient = InfoApiClient(tokenProvider: tokenProvider)
+    private lazy var infoApiClient: PInfoApiClient = InfoApiClient(tokenProvider: tokenProvider, session: httpSession)
     private lazy var serverInfoRepository: PServerInfoRepository = ServerInfoRepository(apiClient: infoApiClient)
     private lazy var annotationsRepository: PAnnotationsRepository = AnnotationsRepository(api: api)
     private lazy var labelsRepository: PLabelsRepository = LabelsRepository(api: api)

--- a/readeckTests/API/APIClientTests.swift
+++ b/readeckTests/API/APIClientTests.swift
@@ -1,0 +1,119 @@
+//
+//  APIClientTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("API Client Tests (injected HTTPSession)")
+@MainActor
+struct APIClientTests {
+
+    // MARK: - ProfileApiClient
+
+    @Test("getProfile decodes the profile and sends a Bearer token")
+    func profileSuccess() async throws {
+        let json = """
+        {
+          "user": { "username": "ilyas", "email": "ilyas@example.com", "created": null, "updated": null },
+          "provider": { "id": "1", "name": "local", "application": null, "roles": null, "permissions": null }
+        }
+        """
+        let session = MockHTTPSession(.json(json))
+        let client = ProfileApiClient(tokenProvider: TestMockTokenProvider(), session: session)
+
+        let profile = try await client.getProfile()
+
+        #expect(profile.user.username == "ilyas")
+        #expect(profile.user.email == "ilyas@example.com")
+        #expect(profile.provider.name == "local")
+        // TestMockTokenProvider liefert "mock-token"
+        #expect(session.lastRequest?.value(forHTTPHeaderField: "authorization") == "Bearer mock-token")
+    }
+
+    @Test("getProfile throws serverError on 5xx")
+    func profileServerError() async throws {
+        let session = MockHTTPSession(.http(status: 500, data: Data()))
+        let client = ProfileApiClient(tokenProvider: TestMockTokenProvider(), session: session)
+
+        await #expect(throws: APIError.serverError(500)) {
+            _ = try await client.getProfile()
+        }
+    }
+
+    @Test("getProfile throws invalidResponse on a non-HTTP response")
+    func profileInvalidResponse() async throws {
+        let url = URL(string: "https://mock.example.com/api/profile")!
+        let nonHTTP = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+        let session = MockHTTPSession(.raw(Data(), nonHTTP))
+        let client = ProfileApiClient(tokenProvider: TestMockTokenProvider(), session: session)
+
+        await #expect(throws: APIError.invalidResponse) {
+            _ = try await client.getProfile()
+        }
+    }
+
+    // MARK: - InfoApiClient
+
+    @Test("getServerInfo decodes a nested version object")
+    func infoNestedVersion() async throws {
+        let json = """
+        { "version": { "canonical": "0.15.0", "release": "0.15.0", "build": "abc" }, "features": ["a"] }
+        """
+        let session = MockHTTPSession(.json(json))
+        let client = InfoApiClient(tokenProvider: TestMockTokenProvider(), session: session)
+
+        let info = try await client.getServerInfo()
+
+        #expect(info.version.canonical == "0.15.0")
+        #expect(info.features == ["a"])
+    }
+
+    @Test("getServerInfo decodes a plain version string defensively")
+    func infoPlainVersionString() async throws {
+        let json = """
+        { "version": "0.14.1" }
+        """
+        let session = MockHTTPSession(.json(json))
+        let client = InfoApiClient(tokenProvider: TestMockTokenProvider(), session: session)
+
+        let info = try await client.getServerInfo()
+
+        #expect(info.version.canonical == "0.14.1")
+    }
+
+    // MARK: - API
+
+    @Test("getBookmarkLabels decodes labels via the injected session")
+    func apiLabelsSuccess() async throws {
+        let json = """
+        [
+          { "name": "swift", "count": 3, "href": "/api/bookmarks/labels/swift" },
+          { "name": "ios", "count": 1, "href": "/api/bookmarks/labels/ios" }
+        ]
+        """
+        let session = MockHTTPSession(.json(json))
+        let api = API(tokenProvider: TestMockTokenProvider(), session: session)
+
+        let labels = try await api.getBookmarkLabels()
+
+        #expect(labels.count == 2)
+        #expect(labels.first?.name == "swift")
+        #expect(labels.first?.count == 3)
+        #expect(session.lastRequest?.url?.absoluteString == "https://mock.example.com/api/bookmarks/labels")
+    }
+
+    @Test("API surfaces serverError from the injected session")
+    func apiServerError() async throws {
+        let session = MockHTTPSession(.http(status: 503, data: Data()))
+        let api = API(tokenProvider: TestMockTokenProvider(), session: session)
+
+        await #expect(throws: APIError.self) {
+            _ = try await api.getBookmarkLabels()
+        }
+    }
+}

--- a/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
+++ b/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
@@ -60,15 +60,19 @@ private final class ArticleRecoveryURLProtocol: URLProtocol {
 
 final class BookmarkArticleRecoveryAPITests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        URLProtocol.registerClass(ArticleRecoveryURLProtocol.self)
-    }
-
     override func tearDown() {
-        URLProtocol.unregisterClass(ArticleRecoveryURLProtocol.self)
         ArticleRecoveryURLProtocol.requestHandler = nil
         super.tearDown()
+    }
+
+    /// API mit einer Session, deren Requests über das Stub-URLProtocol laufen.
+    /// `protocolClasses` in der Konfiguration greift auch bei einer injizierten
+    /// Session - im Gegensatz zu global registrierten Klassen, die nur `URLSession.shared` treffen.
+    private func makeStubbedAPI() -> API {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ArticleRecoveryURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        return API(tokenProvider: TestMockTokenProvider(), session: session)
     }
 
     func testGetBookmarkArticle_502_thenGzipRetryReturns200() async throws {
@@ -94,7 +98,7 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
             return (response, "<p>ok</p>".data(using: .utf8)!)
         }
 
-        let api = API(tokenProvider: TestMockTokenProvider())
+        let api = makeStubbedAPI()
         let html = try await api.getBookmarkArticle(id: "bm1")
         XCTAssertEqual(html, "<p>ok</p>")
     }
@@ -141,7 +145,7 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
             throw URLError(.badURL)
         }
 
-        let api = API(tokenProvider: TestMockTokenProvider())
+        let api = makeStubbedAPI()
         let html = try await api.getBookmarkArticle(id: "bm1")
         XCTAssertEqual(html, "<article>x</article>")
     }
@@ -185,7 +189,7 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
             throw URLError(.badURL)
         }
 
-        let api = API(tokenProvider: TestMockTokenProvider())
+        let api = makeStubbedAPI()
         let html = try await api.getBookmarkArticle(id: "bm1")
         XCTAssertEqual(html, "<article>long</article>")
     }
@@ -226,7 +230,7 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
             throw URLError(.badURL)
         }
 
-        let api = API(tokenProvider: TestMockTokenProvider())
+        let api = makeStubbedAPI()
         let html = try await api.getBookmarkArticle(id: "bm1")
         XCTAssertEqual(html, "<article>y</article>")
     }
@@ -242,7 +246,7 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
             return (response, Data())
         }
 
-        let api = API(tokenProvider: TestMockTokenProvider())
+        let api = makeStubbedAPI()
         do {
             _ = try await api.getBookmarkArticle(id: "bm1")
             XCTFail("Expected error")

--- a/readeckTests/API/HTTPSessionMock.swift
+++ b/readeckTests/API/HTTPSessionMock.swift
@@ -1,0 +1,68 @@
+//
+//  HTTPSessionMock.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Foundation
+@testable import readeck
+
+/// Einfacher HTTPSession-Mock: liefert vorgegebene Antworten nacheinander und
+/// zeichnet die gesendeten Requests auf. Reicht die Stub-Liste nicht aus, wird
+/// der letzte Stub wiederholt.
+final class MockHTTPSession: HTTPSession {
+    enum Stub {
+        /// Erfolgreiche HTTP-Antwort mit Statuscode, Body und optionalen Headern.
+        case http(status: Int, data: Data, headers: [String: String] = [:])
+        /// Beliebige (Data, URLResponse) - z. B. eine Nicht-HTTP-Antwort zum Testen von invalidResponse.
+        case raw(Data, URLResponse)
+        /// Wirft einen Fehler, etwa einen URLError für Server-nicht-erreichbar.
+        case failure(Error)
+    }
+
+    var stubs: [Stub]
+    private(set) var requests: [URLRequest] = []
+    private var index = 0
+
+    init(_ stubs: [Stub]) {
+        self.stubs = stubs
+    }
+
+    convenience init(_ stub: Stub) {
+        self.init([stub])
+    }
+
+    var lastRequest: URLRequest? { requests.last }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+
+        guard let stub = index < stubs.count ? stubs[index] : stubs.last else {
+            throw APIError.invalidResponse
+        }
+        index += 1
+
+        switch stub {
+        case let .http(status, data, headers):
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://mock.example.com")!,
+                statusCode: status,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+            )!
+            return (data, response)
+        case let .raw(data, response):
+            return (data, response)
+        case let .failure(error):
+            throw error
+        }
+    }
+}
+
+extension MockHTTPSession.Stub {
+    /// Bequemer Erfolg mit JSON-String-Body.
+    static func json(_ json: String, status: Int = 200) -> MockHTTPSession.Stub {
+        .http(status: status, data: Data(json.utf8))
+    }
+}

--- a/readeckTests/CoreDataThreadingTests.swift
+++ b/readeckTests/CoreDataThreadingTests.swift
@@ -20,8 +20,7 @@ struct CoreDataThreadingTests {
 
     /// In-memory container mirroring CoreDataManager's merge configuration.
     private func makeContainer() -> NSPersistentContainer {
-        let model = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
-        let container = NSPersistentContainer(name: "readeck", managedObjectModel: model)
+        let container = NSPersistentContainer(name: "readeck", managedObjectModel: TestCoreDataModel.shared)
 
         let description = NSPersistentStoreDescription()
         description.type = NSInMemoryStoreType

--- a/readeckTests/Helpers/TestMocks.swift
+++ b/readeckTests/Helpers/TestMocks.swift
@@ -115,14 +115,25 @@ class TestMockTokenProvider: TokenProvider {
     func getOAuthClientId() async -> String? { return nil }
 }
 
+// MARK: - Shared Test CoreData Model
+
+/// Ein einziges Modell für alle In-Memory-Stores der Tests.
+///
+/// `NSManagedObjectModel.mergedModel(from:)` pro Instanz aufzurufen erzeugt mehrere
+/// Modelle, die dieselbe NSManagedObject-Subklasse beanspruchen. CoreData kann `+entity`
+/// dann nicht mehr auflösen ("Failed to find a unique match for an NSEntityDescription")
+/// und stürzt beim Speichern ab, sobald mehrere CoreData-Suiten im selben Prozess laufen.
+enum TestCoreDataModel {
+    static let shared: NSManagedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
+}
+
 // MARK: - Test CoreData Manager
 
 class TestCoreDataManager {
     let context: NSManagedObjectContext
 
     init() {
-        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
-        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: TestCoreDataModel.shared)
 
         try! persistentStoreCoordinator.addPersistentStore(
             ofType: NSInMemoryStoreType,

--- a/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
+++ b/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
@@ -6,6 +6,11 @@ import Foundation
 private enum Config {
     static let token = "PASTE_TOKEN_HERE"
     static let endpoint = "PASTE_ENDPOINT_HERE"
+
+    /// Ohne echte Zugangsdaten wird der Test übersprungen statt fehlzuschlagen.
+    static var isConfigured: Bool {
+        !token.hasPrefix("PASTE_") && !endpoint.hasPrefix("PASTE_")
+    }
 }
 
 private struct CreateRequest: Encodable {
@@ -36,7 +41,8 @@ private struct ArticleResource: Decodable {
 
 struct HTMLEncodingIntegrationTests {
 
-    @Test func createAndReadBookmarkWithUTF8HTML() async throws {
+    @Test(.enabled(if: Config.isConfigured, "Requires a real Readeck server: fill in TOKEN and ENDPOINT"))
+    func createAndReadBookmarkWithUTF8HTML() async throws {
         let html = """
         <html><head><meta charset="utf-8"></head><body>
         <h1>UTF-8 Test: Ä ö ü ß café 日本語 🎉</h1>

--- a/readeckTests/OfflineCacheRepositoryTests.swift
+++ b/readeckTests/OfflineCacheRepositoryTests.swift
@@ -16,8 +16,7 @@ struct OfflineCacheRepositoryTests {
     // MARK: - Test Setup
 
     private func createInMemoryCoreDataStack() -> NSManagedObjectContext {
-        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
-        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: TestCoreDataModel.shared)
 
         try! persistentStoreCoordinator.addPersistentStore(
             ofType: NSInMemoryStoreType,


### PR DESCRIPTION
Führt ein schmales `HTTPSession`-Protokoll ein, das `URLSession` nativ erfüllt, plus eine Factory mit Timeouts (30s Request / 120s Resource statt 60s-Default). Ersetzt alle 14 direkten `URLSession.shared`-Aufrufe im Hauptmodul und schaltet die Repository-Tests frei.

`waitsForConnectivity` bleibt bewusst aus, sonst bekäme `OfflineSyncManager` statt eines schnellen `notConnectedToInternet` erst nach 120s ein `.timedOut` und die Offline-Erkennung liefe ins Leere.

Zusätzlich zwei vorbestehende Testprobleme gefixt (zweiter Commit): geteiltes `NSManagedObjectModel` gegen CoreData-Crash bei mehreren Suiten, und der server-abhängige Integrationstest wird jetzt übersprungen statt fehlzuschlagen.

Verifiziert: 241 Tests in 25 Suiten grün.

Closes #82