### PR TITLE
test(repository): cover Bookmarks, Labels, Auth and Settings

### DIFF
--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -6,10 +6,23 @@ final class CoreDataManager {
 
     private var isInMemoryStore = false
     private let logger = Logger.data
+    private let injectedContainer: NSPersistentContainer?
 
-    private init() {}
+    private init() {
+        self.injectedContainer = nil
+    }
+
+    /// Erlaubt einen vorkonfigurierten Container, etwa einen In-Memory-Store in Tests.
+    /// Der reguläre App-Pfad läuft weiter über `shared`.
+    init(container: NSPersistentContainer) {
+        self.injectedContainer = container
+    }
 
     lazy var persistentContainer: NSPersistentContainer = {
+        if let injectedContainer {
+            return injectedContainer
+        }
+
         // Try to find the model in the main bundle first, then in extension bundle
         guard let modelURL = Bundle.main.url(forResource: "readeck", withExtension: "momd") ??
                              Bundle(for: CoreDataManager.self).url(forResource: "readeck", withExtension: "momd") else {

--- a/readeck/Data/Repository/LabelsRepository.swift
+++ b/readeck/Data/Repository/LabelsRepository.swift
@@ -4,10 +4,11 @@ import CoreData
 final class LabelsRepository: PLabelsRepository, @unchecked Sendable {
     private let api: PAPI
 
-    private let coreDataManager = CoreDataManager.shared
+    private let coreDataManager: CoreDataManager
 
-    init(api: PAPI) {
+    init(api: PAPI, coreDataManager: CoreDataManager = .shared) {
         self.api = api
+        self.coreDataManager = coreDataManager
     }
 
     func getLabels() async throws -> [BookmarkLabel] {

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -3,13 +3,19 @@ import CoreData
 import Kingfisher
 
 final class SettingsRepository: PSettingsRepository {
-    private let coreDataManager = CoreDataManager.shared
-    private let userDefault = UserDefaults.standard
+    private let coreDataManager: CoreDataManager
+    private let userDefault: UserDefaults
     private let keychainHelper = KeychainHelper.shared
     private let tokenProvider: TokenProvider
 
-    init(tokenProvider: TokenProvider = KeychainTokenProvider()) {
+    init(
+        tokenProvider: TokenProvider = KeychainTokenProvider(),
+        coreDataManager: CoreDataManager = .shared,
+        userDefaults: UserDefaults = .standard
+    ) {
         self.tokenProvider = tokenProvider
+        self.coreDataManager = coreDataManager
+        self.userDefault = userDefaults
     }
 
     var hasFinishedSetup: Bool {

--- a/readeckTests/Helpers/RepositoryTestSupport.swift
+++ b/readeckTests/Helpers/RepositoryTestSupport.swift
@@ -1,0 +1,314 @@
+//
+//  RepositoryTestSupport.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Foundation
+import CoreData
+@testable import readeck
+
+// MARK: - Stub API
+
+/// PAPI-Stub mit Closure-Handlern statt `fatalError`-Platzhaltern.
+/// Nicht gesetzte Handler werfen `notStubbed`, damit ein Test sofort zeigt,
+/// welchen Aufruf er nicht erwartet hat.
+final class StubAPI: PAPI, @unchecked Sendable {
+    enum StubError: Error, Equatable {
+        case notStubbed(String)
+    }
+
+    var tokenProvider: TokenProvider = TestMockTokenProvider()
+
+    // swiftlint:disable:next discouraged_optional_collection
+    var getBookmarksHandler: ((BookmarkState?, Int?, Int?, String?, [BookmarkType]?, String?, String?) async throws -> BookmarksPageDto)?
+    var getBookmarkHandler: ((String) async throws -> BookmarkDetailDto)?
+    var getBookmarkArticleHandler: ((String) async throws -> String)?
+    var createBookmarkHandler: ((CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto)?
+    var updateBookmarkHandler: ((String, UpdateBookmarkRequestDto) async throws -> Void)?
+    var deleteBookmarkHandler: ((String) async throws -> Void)?
+    var searchBookmarksHandler: ((String) async throws -> BookmarksPageDto)?
+    var getBookmarkLabelsHandler: (() async throws -> [BookmarkLabelDto])?
+    var loginHandler: ((String, String, String) async throws -> UserDto)?
+
+    // Aufzeichnungen für Assertions
+    private(set) var updateBookmarkCalls: [(String, UpdateBookmarkRequestDto)] = []
+    private(set) var deleteBookmarkCalls: [String] = []
+    private(set) var createBookmarkCalls: [CreateBookmarkRequestDto] = []
+
+    func login(endpoint: String, username: String, password: String) async throws -> UserDto {
+        guard let loginHandler else { throw StubError.notStubbed("login") }
+        return try await loginHandler(endpoint, username, password)
+    }
+
+    // swiftlint:disable:next discouraged_optional_collection
+    func getBookmarks(state: BookmarkState?, limit: Int?, offset: Int?, search: String?, type: [BookmarkType]?, tag: String?, sort: String?) async throws -> BookmarksPageDto {
+        guard let getBookmarksHandler else { throw StubError.notStubbed("getBookmarks") }
+        return try await getBookmarksHandler(state, limit, offset, search, type, tag, sort)
+    }
+
+    func getBookmark(id: String) async throws -> BookmarkDetailDto {
+        guard let getBookmarkHandler else { throw StubError.notStubbed("getBookmark") }
+        return try await getBookmarkHandler(id)
+    }
+
+    func getBookmarkArticle(id: String) async throws -> String {
+        guard let getBookmarkArticleHandler else { throw StubError.notStubbed("getBookmarkArticle") }
+        return try await getBookmarkArticleHandler(id)
+    }
+
+    func createBookmark(createRequest: CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto {
+        createBookmarkCalls.append(createRequest)
+        guard let createBookmarkHandler else { throw StubError.notStubbed("createBookmark") }
+        return try await createBookmarkHandler(createRequest)
+    }
+
+    func updateBookmark(id: String, updateRequest: UpdateBookmarkRequestDto) async throws {
+        updateBookmarkCalls.append((id, updateRequest))
+        guard let updateBookmarkHandler else { throw StubError.notStubbed("updateBookmark") }
+        try await updateBookmarkHandler(id, updateRequest)
+    }
+
+    func deleteBookmark(id: String) async throws {
+        deleteBookmarkCalls.append(id)
+        guard let deleteBookmarkHandler else { throw StubError.notStubbed("deleteBookmark") }
+        try await deleteBookmarkHandler(id)
+    }
+
+    func searchBookmarks(search: String) async throws -> BookmarksPageDto {
+        guard let searchBookmarksHandler else { throw StubError.notStubbed("searchBookmarks") }
+        return try await searchBookmarksHandler(search)
+    }
+
+    func getBookmarkLabels() async throws -> [BookmarkLabelDto] {
+        guard let getBookmarkLabelsHandler else { throw StubError.notStubbed("getBookmarkLabels") }
+        return try await getBookmarkLabelsHandler()
+    }
+
+    func getBookmarkAnnotations(bookmarkId: String) async throws -> [AnnotationDto] { [] }
+
+    func createAnnotation(bookmarkId: String, color: String, startOffset: Int, endOffset: Int, startSelector: String, endSelector: String) async throws -> AnnotationDto {
+        throw StubError.notStubbed("createAnnotation")
+    }
+
+    func deleteAnnotation(bookmarkId: String, annotationId: String) async throws {
+        throw StubError.notStubbed("deleteAnnotation")
+    }
+
+    func registerOAuthClient(endpoint: String, request: OAuthClientCreateDto) async throws -> OAuthClientResponseDto {
+        throw StubError.notStubbed("registerOAuthClient")
+    }
+
+    func exchangeOAuthToken(endpoint: String, request: OAuthTokenRequestDto) async throws -> OAuthTokenResponseDto {
+        throw StubError.notStubbed("exchangeOAuthToken")
+    }
+}
+
+// MARK: - Recording Token Provider
+
+/// TokenProvider, der Schreibzugriffe im Speicher hält und mitschreibt.
+final class RecordingTokenProvider: TokenProvider, @unchecked Sendable {
+    private(set) var token: String?
+    private(set) var endpoint: String?
+    private(set) var oauthToken: OAuthToken?
+    private(set) var authMethod: AuthenticationMethod?
+    private(set) var oauthClientId: String?
+    private(set) var clearTokenCallCount = 0
+
+    init(token: String? = "existing-token", endpoint: String? = "https://mock.example.com") {
+        self.token = token
+        self.endpoint = endpoint
+    }
+
+    func getToken() async -> String? { token }
+    func setToken(_ token: String) async { self.token = token }
+    func clearToken() async {
+        clearTokenCallCount += 1
+        token = nil
+    }
+    func getEndpoint() async -> String? { endpoint }
+    func setEndpoint(_ endpoint: String) async { self.endpoint = endpoint }
+    func clearEndpoint() async { endpoint = nil }
+
+    func getOAuthToken() async -> OAuthToken? { oauthToken }
+    func setOAuthToken(_ token: OAuthToken) async { oauthToken = token }
+    func getAuthMethod() async -> AuthenticationMethod? { authMethod }
+    func setAuthMethod(_ method: AuthenticationMethod) async { authMethod = method }
+    func setOAuthClientId(_ clientId: String) async { oauthClientId = clientId }
+    func getOAuthClientId() async -> String? { oauthClientId }
+}
+
+// MARK: - Recording Settings Repository
+
+/// PSettingsRepository-Double, das gespeicherte Settings festhält.
+/// `MockSettingsRepository` aus dem App-Target hat feste Rückgaben und zeichnet nichts auf.
+final class RecordingSettingsRepository: PSettingsRepository, @unchecked Sendable {
+    var storedSettings: Settings?
+    var loadSettingsError: Error?
+    private(set) var savedSettings: [Settings] = []
+
+    var hasFinishedSetup = true
+
+    init(storedSettings: Settings? = Settings()) {
+        self.storedSettings = storedSettings
+    }
+
+    func saveSettings(_ settings: Settings) async throws {
+        savedSettings.append(settings)
+        storedSettings = settings
+    }
+
+    func loadSettings() async throws -> Settings? {
+        if let loadSettingsError { throw loadSettingsError }
+        return storedSettings
+    }
+
+    func clearSettings() async throws { storedSettings = nil }
+    func saveToken(_ token: String) async throws {}
+    func saveUsername(_ username: String) async throws {}
+    func savePassword(_ password: String) async throws {}
+    func saveHasFinishedSetup(_ hasFinishedSetup: Bool) async throws { self.hasFinishedSetup = hasFinishedSetup }
+    func saveServerSettings(endpoint: String, username: String, password: String, token: String) async throws {}
+    func saveCardLayoutStyle(_ cardLayoutStyle: CardLayoutStyle) async throws {}
+    func loadCardLayoutStyle() async throws -> CardLayoutStyle { .magazine }
+    func saveTagSortOrder(_ tagSortOrder: TagSortOrder) async throws {}
+    func loadTagSortOrder() async throws -> TagSortOrder { .byCount }
+    func loadOfflineSettings() async throws -> OfflineSettings { OfflineSettings() }
+    func saveOfflineSettings(_ settings: OfflineSettings) async throws {}
+    func getCacheSize() async throws -> UInt { 0 }
+    func getMaxCacheSize() async throws -> UInt { 200 * 1024 * 1024 }
+    func updateMaxCacheSize(_ sizeInBytes: UInt) async throws {}
+    func clearCache() async throws {}
+    func applyCacheSizeLimit() async throws {}
+}
+
+// MARK: - Stub GetUserProfileUseCase
+
+final class StubGetUserProfileUseCase: PGetUserProfileUseCase, @unchecked Sendable {
+    var result: Result<String, Error>
+
+    init(username: String = "ilyas") {
+        self.result = .success(username)
+    }
+
+    func execute() async throws -> String {
+        try result.get()
+    }
+}
+
+// MARK: - OAuth Fixtures
+
+extension OAuthToken {
+    static func fixture(
+        accessToken: String = "access-123",
+        refreshToken: String? = "refresh-123",
+        expiresIn: Int? = 3600
+    ) -> OAuthToken {
+        OAuthToken(
+            accessToken: accessToken,
+            tokenType: "Bearer",
+            scope: nil,
+            expiresIn: expiresIn,
+            refreshToken: refreshToken,
+            createdAt: Date(timeIntervalSince1970: 1_767_225_600)
+        )
+    }
+}
+
+// MARK: - In-Memory CoreDataManager
+
+extension CoreDataManager {
+    /// CoreDataManager auf einem In-Memory-Store, für Repositories die den Manager injiziert bekommen.
+    static func inMemory() -> CoreDataManager {
+        let container = NSPersistentContainer(name: "readeck", managedObjectModel: TestCoreDataModel.shared)
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+
+        container.loadPersistentStores { _, error in
+            precondition(error == nil, "In-memory store failed to load: \(String(describing: error))")
+        }
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        return CoreDataManager(container: container)
+    }
+}
+
+// MARK: - Isolated UserDefaults
+
+/// UserDefaults in einer eigenen Suite, damit Tests sich nicht gegenseitig
+/// und nicht die echten App-Einstellungen beeinflussen.
+func makeIsolatedUserDefaults(suiteName: String = UUID().uuidString) -> UserDefaults {
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+        preconditionFailure("Could not create UserDefaults suite \(suiteName)")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+}
+
+// MARK: - DTO Fixtures
+
+enum DtoFixture {
+    static func bookmark(
+        id: String = "bm1",
+        title: String = "Test Bookmark",
+        labels: [String] = [],
+        isArchived: Bool = false,
+        isMarked: Bool = false,
+        readProgress: Int = 0
+    ) -> BookmarkDto {
+        BookmarkDto(
+            id: id,
+            title: title,
+            url: "https://example.com/\(id)",
+            href: "https://api.example.com/bookmarks/\(id)",
+            description: "A description",
+            authors: ["Author"],
+            created: "2026-01-01T00:00:00Z",
+            published: nil,
+            updated: "2026-01-02T00:00:00Z",
+            siteName: "Example",
+            site: "example.com",
+            readingTime: 5,
+            wordCount: 1000,
+            hasArticle: true,
+            isArchived: isArchived,
+            isDeleted: false,
+            isMarked: isMarked,
+            labels: labels,
+            lang: "en",
+            loaded: true,
+            readProgress: readProgress,
+            documentType: "article",
+            state: 0,
+            textDirection: "ltr",
+            type: "article",
+            resources: BookmarkResourcesDto(
+                article: ResourceDto(src: "https://example.com/\(id)/article"),
+                icon: nil,
+                image: ImageResourceDto(src: "https://example.com/\(id)/image.jpg", height: 600, width: 800),
+                log: nil,
+                props: nil,
+                thumbnail: ImageResourceDto(src: "https://example.com/\(id)/thumb.jpg", height: 150, width: 200)
+            )
+        )
+    }
+
+    static func page(
+        bookmarks: [BookmarkDto],
+        currentPage: Int? = 1,
+        totalCount: Int? = nil,
+        totalPages: Int? = 1
+    ) -> BookmarksPageDto {
+        BookmarksPageDto(
+            bookmarks: bookmarks,
+            currentPage: currentPage,
+            totalCount: totalCount ?? bookmarks.count,
+            totalPages: totalPages,
+            links: nil
+        )
+    }
+}

--- a/readeckTests/Repository/AuthRepositoryTests.swift
+++ b/readeckTests/Repository/AuthRepositoryTests.swift
@@ -1,0 +1,190 @@
+//
+//  AuthRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("AuthRepository Tests")
+struct AuthRepositoryTests {
+
+    private func makeRepository(
+        tokenProvider: RecordingTokenProvider = RecordingTokenProvider(),
+        settings: RecordingSettingsRepository = RecordingSettingsRepository(),
+        profile: StubGetUserProfileUseCase = StubGetUserProfileUseCase()
+    ) -> (AuthRepository, StubAPI, RecordingTokenProvider, RecordingSettingsRepository) {
+        let api = StubAPI()
+        api.tokenProvider = tokenProvider
+        let repository = AuthRepository(
+            api: api,
+            settingsRepository: settings,
+            getUserProfileUseCase: profile
+        )
+        return (repository, api, tokenProvider, settings)
+    }
+
+    // MARK: - Classic Login
+
+    @Test("login returns the user and switches the auth method to apiToken")
+    func loginSucceeds() async throws {
+        let (repository, api, tokenProvider, _) = makeRepository()
+        api.loginHandler = { _, _, _ in UserDto(id: "u1", token: "tok-1") }
+
+        let user = try await repository.login(
+            endpoint: "https://readeck.example.com", username: "ilyas", password: "pw"
+        )
+
+        #expect(user.id == "u1")
+        #expect(user.token == "tok-1")
+        #expect(tokenProvider.authMethod == .apiToken)
+    }
+
+    @Test("login passes the credentials through to the API")
+    func loginForwardsCredentials() async throws {
+        let (repository, api, _, _) = makeRepository()
+        var received: (endpoint: String, username: String, password: String)?
+        api.loginHandler = { endpoint, username, password in
+            received = (endpoint, username, password)
+            return UserDto(id: "u1", token: "tok-1")
+        }
+
+        _ = try await repository.login(
+            endpoint: "https://readeck.example.com", username: "ilyas", password: "secret"
+        )
+
+        #expect(received?.endpoint == "https://readeck.example.com")
+        #expect(received?.username == "ilyas")
+        #expect(received?.password == "secret")
+    }
+
+    @Test("login propagates an API error and leaves the auth method untouched")
+    func loginPropagatesError() async throws {
+        let (repository, api, tokenProvider, _) = makeRepository()
+        api.loginHandler = { _, _, _ in throw APIError.serverError(401) }
+
+        await #expect(throws: APIError.serverError(401)) {
+            _ = try await repository.login(endpoint: "https://x", username: "a", password: "b")
+        }
+        #expect(tokenProvider.authMethod == nil)
+    }
+
+    // MARK: - Logout
+
+    @Test("logout clears the token and resets the auth method")
+    func logoutClearsToken() async throws {
+        let (repository, _, tokenProvider, _) = makeRepository()
+
+        try await repository.logout()
+
+        #expect(tokenProvider.clearTokenCallCount == 1)
+        #expect(tokenProvider.token == nil)
+        #expect(tokenProvider.authMethod == .apiToken)
+    }
+
+    // MARK: - OAuth Login
+
+    @Test("loginWithOAuth persists token, method, client id and endpoint")
+    func oauthPersistsCredentials() async throws {
+        let (repository, _, tokenProvider, _) = makeRepository()
+        let token = OAuthToken.fixture()
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: token, clientId: "client-1"
+        )
+
+        #expect(tokenProvider.oauthToken?.accessToken == "access-123")
+        #expect(tokenProvider.authMethod == .oauth)
+        #expect(tokenProvider.oauthClientId == "client-1")
+        #expect(tokenProvider.endpoint == "https://readeck.example.com")
+    }
+
+    @Test("loginWithOAuth writes endpoint and username into the settings")
+    func oauthUpdatesSettings() async throws {
+        let settings = RecordingSettingsRepository(storedSettings: Settings())
+        let (repository, _, _, _) = makeRepository(
+            settings: settings, profile: StubGetUserProfileUseCase(username: "ilyas")
+        )
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: .fixture(), clientId: "client-1"
+        )
+
+        #expect(settings.savedSettings.count == 1)
+        #expect(settings.savedSettings.first?.endpoint == "https://readeck.example.com")
+        #expect(settings.savedSettings.first?.username == "ilyas")
+    }
+
+    @Test("loginWithOAuth skips the settings write when none are stored yet")
+    func oauthWithoutExistingSettings() async throws {
+        let settings = RecordingSettingsRepository(storedSettings: nil)
+        let (repository, _, tokenProvider, _) = makeRepository(settings: settings)
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: .fixture(), clientId: "client-1"
+        )
+
+        // Der Token-Teil muss trotzdem persistiert sein.
+        #expect(tokenProvider.authMethod == .oauth)
+        #expect(settings.savedSettings.isEmpty)
+    }
+
+    @Test("loginWithOAuth propagates a failing profile fetch")
+    func oauthPropagatesProfileError() async throws {
+        let profile = StubGetUserProfileUseCase()
+        profile.result = .failure(APIError.serverError(403))
+        let (repository, _, _, settings) = makeRepository(profile: profile)
+
+        await #expect(throws: APIError.serverError(403)) {
+            try await repository.loginWithOAuth(
+                endpoint: "https://x", token: .fixture(), clientId: "c"
+            )
+        }
+        #expect(settings.savedSettings.isEmpty)
+    }
+
+    // MARK: - Auth Method / Switching
+
+    @Test("getAuthenticationMethod reads through to the token provider")
+    func getAuthenticationMethod() async throws {
+        let tokenProvider = RecordingTokenProvider()
+        await tokenProvider.setAuthMethod(.oauth)
+        let (repository, _, _, _) = makeRepository(tokenProvider: tokenProvider)
+
+        #expect(await repository.getAuthenticationMethod() == .oauth)
+    }
+
+    @Test("switchToClassicAuth clears the old token before logging in again")
+    func switchToClassicAuth() async throws {
+        let tokenProvider = RecordingTokenProvider()
+        await tokenProvider.setAuthMethod(.oauth)
+        let (repository, api, provider, _) = makeRepository(tokenProvider: tokenProvider)
+        api.loginHandler = { _, _, _ in UserDto(id: "u2", token: "tok-2") }
+
+        let user = try await repository.switchToClassicAuth(
+            endpoint: "https://x", username: "a", password: "b"
+        )
+
+        #expect(user.id == "u2")
+        #expect(provider.clearTokenCallCount == 1)
+        #expect(provider.authMethod == .apiToken)
+    }
+
+    // MARK: - getCurrentSettings
+
+    @Test("getCurrentSettings reads through to the settings repository")
+    func getCurrentSettings() async throws {
+        var stored = Settings()
+        stored.endpoint = "https://stored.example.com"
+        let (repository, _, _, _) = makeRepository(
+            settings: RecordingSettingsRepository(storedSettings: stored)
+        )
+
+        let settings = try await repository.getCurrentSettings()
+
+        #expect(settings?.endpoint == "https://stored.example.com")
+    }
+}

--- a/readeckTests/Repository/BookmarksRepositoryTests.swift
+++ b/readeckTests/Repository/BookmarksRepositoryTests.swift
@@ -1,0 +1,182 @@
+//
+//  BookmarksRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("BookmarksRepository Tests")
+struct BookmarksRepositoryTests {
+
+    // MARK: - fetchBookmarks / DTO → Domain
+
+    @Test("fetchBookmarks maps the page and all bookmark fields to the domain model")
+    func fetchBookmarksMapsToDomain() async throws {
+        let api = StubAPI()
+        api.getBookmarksHandler = { _, _, _, _, _, _, _ in
+            DtoFixture.page(
+                bookmarks: [DtoFixture.bookmark(id: "a", title: "First", labels: ["swift"], isMarked: true)],
+                currentPage: 2,
+                totalCount: 42,
+                totalPages: 5
+            )
+        }
+        let repository = BookmarksRepository(api: api)
+
+        let page = try await repository.fetchBookmarks()
+
+        #expect(page.currentPage == 2)
+        #expect(page.totalCount == 42)
+        #expect(page.totalPages == 5)
+        #expect(page.bookmarks.count == 1)
+
+        let bookmark = try #require(page.bookmarks.first)
+        #expect(bookmark.id == "a")
+        #expect(bookmark.title == "First")
+        #expect(bookmark.url == "https://example.com/a")
+        #expect(bookmark.labels == ["swift"])
+        #expect(bookmark.isMarked == true)
+        #expect(bookmark.isArchived == false)
+        #expect(bookmark.readingTime == 5)
+        #expect(bookmark.wordCount == 1000)
+        // Verschachteltes Resource-Mapping
+        #expect(bookmark.resources.article?.src == "https://example.com/a/article")
+        #expect(bookmark.resources.thumbnail?.src == "https://example.com/a/thumb.jpg")
+        #expect(bookmark.resources.image?.width == 800)
+        #expect(bookmark.resources.icon == nil)
+    }
+
+    @Test("fetchBookmarks forwards its filter arguments to the API unchanged")
+    func fetchBookmarksForwardsArguments() async throws {
+        let api = StubAPI()
+        var received: (state: BookmarkState?, limit: Int?, offset: Int?, search: String?, tag: String?, sort: String?)?
+        api.getBookmarksHandler = { state, limit, offset, search, _, tag, sort in
+            received = (state, limit, offset, search, tag, sort)
+            return DtoFixture.page(bookmarks: [])
+        }
+        let repository = BookmarksRepository(api: api)
+
+        _ = try await repository.fetchBookmarks(
+            state: .unread, limit: 10, offset: 20, search: "swift", type: nil, tag: "ios", sort: "-created"
+        )
+
+        #expect(received?.state == .unread)
+        #expect(received?.limit == 10)
+        #expect(received?.offset == 20)
+        #expect(received?.search == "swift")
+        #expect(received?.tag == "ios")
+        #expect(received?.sort == "-created")
+    }
+
+    @Test("fetchBookmarks propagates API errors")
+    func fetchBookmarksPropagatesError() async throws {
+        let api = StubAPI()
+        api.getBookmarksHandler = { _, _, _, _, _, _, _ in throw APIError.serverError(500) }
+        let repository = BookmarksRepository(api: api)
+
+        await #expect(throws: APIError.serverError(500)) {
+            _ = try await repository.fetchBookmarks()
+        }
+    }
+
+    // MARK: - fetchBookmark
+
+    @Test("fetchBookmark maps the detail, flattening resource URLs")
+    func fetchBookmarkMapsDetail() async throws {
+        let api = StubAPI()
+        api.getBookmarkHandler = { id in DtoFixture.bookmark(id: id, title: "Detail", labels: ["a", "b"]) }
+        let repository = BookmarksRepository(api: api)
+
+        let detail = try await repository.fetchBookmark(id: "bm42")
+
+        #expect(detail.id == "bm42")
+        #expect(detail.title == "Detail")
+        #expect(detail.labels == ["a", "b"])
+        #expect(detail.thumbnailUrl == "https://example.com/bm42/thumb.jpg")
+        #expect(detail.imageUrl == "https://example.com/bm42/image.jpg")
+        #expect(detail.lang == "en")
+        #expect(detail.hasArticle == true)
+    }
+
+    // MARK: - createBookmark
+
+    @Test("createBookmark returns the message on an accepted status", arguments: [0, 202])
+    func createBookmarkSuccess(status: Int) async throws {
+        let api = StubAPI()
+        api.createBookmarkHandler = { _ in CreateBookmarkResponseDto(message: "new-id", status: status) }
+        let repository = BookmarksRepository(api: api)
+
+        let id = try await repository.createBookmark(
+            createRequest: CreateBookmarkRequest(url: "https://example.com", title: "T", labels: ["x"])
+        )
+
+        #expect(id == "new-id")
+        #expect(api.createBookmarkCalls.count == 1)
+        #expect(api.createBookmarkCalls[0].url == "https://example.com")
+        #expect(api.createBookmarkCalls[0].labels == ["x"])
+    }
+
+    @Test("createBookmark throws a serverError on an unexpected status")
+    func createBookmarkRejectsUnexpectedStatus() async throws {
+        let api = StubAPI()
+        api.createBookmarkHandler = { _ in CreateBookmarkResponseDto(message: "nope", status: 500) }
+        let repository = BookmarksRepository(api: api)
+
+        await #expect(throws: CreateBookmarkError.self) {
+            _ = try await repository.createBookmark(
+                createRequest: CreateBookmarkRequest(url: "https://example.com", title: nil, labels: nil)
+            )
+        }
+    }
+
+    // MARK: - update / delete
+
+    @Test("updateBookmark passes the id and maps the request to its DTO")
+    func updateBookmarkMapsRequest() async throws {
+        let api = StubAPI()
+        api.updateBookmarkHandler = { _, _ in }
+        let repository = BookmarksRepository(api: api)
+
+        try await repository.updateBookmark(
+            id: "bm1",
+            updateRequest: BookmarkUpdateRequest(isArchived: true, isMarked: false, readProgress: 80)
+        )
+
+        #expect(api.updateBookmarkCalls.count == 1)
+        #expect(api.updateBookmarkCalls[0].0 == "bm1")
+        #expect(api.updateBookmarkCalls[0].1.isArchived == true)
+        #expect(api.updateBookmarkCalls[0].1.isMarked == false)
+        #expect(api.updateBookmarkCalls[0].1.readProgress == 80)
+    }
+
+    @Test("deleteBookmark forwards the id")
+    func deleteBookmarkForwardsId() async throws {
+        let api = StubAPI()
+        api.deleteBookmarkHandler = { _ in }
+        let repository = BookmarksRepository(api: api)
+
+        try await repository.deleteBookmark(id: "bm9")
+
+        #expect(api.deleteBookmarkCalls == ["bm9"])
+    }
+
+    // MARK: - searchBookmarks
+
+    @Test("searchBookmarks maps results to the domain model")
+    func searchBookmarksMapsResults() async throws {
+        let api = StubAPI()
+        api.searchBookmarksHandler = { term in
+            DtoFixture.page(bookmarks: [DtoFixture.bookmark(id: "s1", title: "Found \(term)")])
+        }
+        let repository = BookmarksRepository(api: api)
+
+        let page = try await repository.searchBookmarks(search: "swift")
+
+        #expect(page.bookmarks.count == 1)
+        #expect(page.bookmarks.first?.title == "Found swift")
+    }
+}

--- a/readeckTests/Repository/LabelsRepositoryTests.swift
+++ b/readeckTests/Repository/LabelsRepositoryTests.swift
@@ -1,0 +1,137 @@
+//
+//  LabelsRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+import CoreData
+@testable import readeck
+
+@Suite("LabelsRepository Tests")
+struct LabelsRepositoryTests {
+
+    private func makeRepository() -> (LabelsRepository, StubAPI, CoreDataManager) {
+        let api = StubAPI()
+        let coreData = CoreDataManager.inMemory()
+        return (LabelsRepository(api: api, coreDataManager: coreData), api, coreData)
+    }
+
+    private func fetchTags(_ coreData: CoreDataManager) throws -> [TagEntity] {
+        let context = coreData.context
+        return try context.performAndWait {
+            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+            return try context.fetch(request)
+        }
+    }
+
+    // MARK: - saveLabels
+
+    @Test("saveLabels inserts new labels with their counts")
+    func saveLabelsInserts() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveLabels([
+            BookmarkLabelDto(name: "swift", count: 3, href: "/swift"),
+            BookmarkLabelDto(name: "ios", count: 1, href: "/ios")
+        ])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 2)
+        #expect(tags.map(\.name) == ["ios", "swift"])
+        #expect(tags.first { $0.name == "swift" }?.count == 3)
+    }
+
+    @Test("saveLabels updates the count of an existing label instead of duplicating it")
+    func saveLabelsUpdatesExisting() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 3, href: "/swift")])
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 7, href: "/swift")])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.count == 7)
+    }
+
+    // MARK: - saveNewLabel
+
+    @Test("saveNewLabel creates a label with count 1")
+    func saveNewLabelCreates() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "kotlin")
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.name == "kotlin")
+        #expect(tags.first?.count == 1)
+    }
+
+    @Test("saveNewLabel trims whitespace and ignores blank names")
+    func saveNewLabelTrimsAndIgnoresBlank() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "  spaced  ")
+        try await repository.saveNewLabel(name: "   ")
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.name == "spaced")
+    }
+
+    @Test("saveNewLabel does not duplicate an existing label")
+    func saveNewLabelDeduplicates() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "swift")
+        try await repository.saveNewLabel(name: "swift")
+
+        #expect(try fetchTags(coreData).count == 1)
+    }
+
+    // MARK: - getLabels
+
+    @Test("getLabels returns the cached labels sorted by count, then name")
+    func getLabelsReturnsCacheSorted() async throws {
+        let (repository, api, _) = makeRepository()
+        // Der Hintergrund-Refresh darf den Test nicht beeinflussen.
+        api.getBookmarkLabelsHandler = { [] }
+
+        try await repository.saveLabels([
+            BookmarkLabelDto(name: "rare", count: 1, href: "/rare"),
+            BookmarkLabelDto(name: "common", count: 9, href: "/common"),
+            BookmarkLabelDto(name: "alpha", count: 9, href: "/alpha")
+        ])
+
+        let labels = try await repository.getLabels()
+
+        // count absteigend, bei Gleichstand name aufsteigend
+        #expect(labels.map(\.name) == ["alpha", "common", "rare"])
+        #expect(labels.first?.count == 9)
+    }
+
+    @Test("getLabels returns an empty list when nothing is cached")
+    func getLabelsEmptyCache() async throws {
+        let (repository, api, _) = makeRepository()
+        api.getBookmarkLabelsHandler = { [] }
+
+        let labels = try await repository.getLabels()
+
+        #expect(labels.isEmpty)
+    }
+
+    @Test("getLabels still returns cached data when the background sync fails")
+    func getLabelsSurvivesFailingSync() async throws {
+        let (repository, api, _) = makeRepository()
+        api.getBookmarkLabelsHandler = { throw APIError.serverError(500) }
+
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 2, href: "/swift")])
+        let labels = try await repository.getLabels()
+
+        #expect(labels.map(\.name) == ["swift"])
+    }
+}

--- a/readeckTests/Repository/SettingsRepositoryTests.swift
+++ b/readeckTests/Repository/SettingsRepositoryTests.swift
@@ -1,0 +1,204 @@
+//
+//  SettingsRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+/// Deckt die CoreData- und UserDefaults-gestützten Pfade ab.
+/// Die Keychain-Felder (endpoint/username/password/token) bleiben ausgespart:
+/// `SettingsRepository` greift dafür fest auf `KeychainHelper.shared` zu, ein Test
+/// würde den echten Keychain des Geräts anfassen.
+@Suite("SettingsRepository Tests")
+struct SettingsRepositoryTests {
+
+    private func makeRepository() -> (SettingsRepository, UserDefaults) {
+        let defaults = makeIsolatedUserDefaults()
+        let repository = SettingsRepository(
+            tokenProvider: RecordingTokenProvider(),
+            coreDataManager: .inMemory(),
+            userDefaults: defaults
+        )
+        return (repository, defaults)
+    }
+
+    // MARK: - UI Preferences Round-Trip
+
+    @Test("saveSettings persists the UI preferences and loadSettings reads them back")
+    func uiPreferencesRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        var settings = Settings()
+        settings.fontFamily = .serif
+        settings.fontSize = .large
+        settings.theme = .dark
+        settings.enableTTS = true
+        settings.cardLayoutStyle = .compact
+        settings.tagSortOrder = .alphabetically
+
+        try await repository.saveSettings(settings)
+        let loaded = try #require(try await repository.loadSettings())
+
+        #expect(loaded.fontFamily == .serif)
+        #expect(loaded.fontSize == .large)
+        #expect(loaded.theme == .dark)
+        #expect(loaded.enableTTS == true)
+        #expect(loaded.cardLayoutStyle == .compact)
+        #expect(loaded.tagSortOrder == .alphabetically)
+    }
+
+    @Test("loadSettings falls back to defaults on an empty store")
+    func loadSettingsDefaults() async throws {
+        let (repository, _) = makeRepository()
+
+        let loaded = try #require(try await repository.loadSettings())
+
+        #expect(loaded.fontFamily == .system)
+        #expect(loaded.fontSize == .medium)
+        #expect(loaded.theme == .system)
+        #expect(loaded.cardLayoutStyle == .magazine)
+        #expect(loaded.tagSortOrder == .byCount)
+    }
+
+    @Test("saveSettings updates the existing entity instead of adding a second one")
+    func saveSettingsUpdatesInPlace() async throws {
+        let (repository, _) = makeRepository()
+
+        var first = Settings()
+        first.fontSize = .small
+        try await repository.saveSettings(first)
+
+        var second = Settings()
+        second.fontSize = .large
+        try await repository.saveSettings(second)
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.fontSize == .large)
+    }
+
+    // MARK: - Reader Styling Sentinels
+
+    @Test("horizontalMargin 0 survives the round-trip, since 0 is a valid value")
+    func horizontalMarginZeroIsPreserved() async throws {
+        let (repository, _) = makeRepository()
+
+        var settings = Settings()
+        settings.horizontalMargin = 0
+        try await repository.saveSettings(settings)
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == 0)
+    }
+
+    @Test("unset fontSizeNumeric and lineHeight come back as nil rather than 0")
+    func unsetNumericValuesAreNil() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveSettings(Settings())
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.fontSizeNumeric == nil)
+        #expect(loaded.lineHeight == nil)
+    }
+
+    // Dokumentiert das Ist-Verhalten, nicht das gewünschte:
+    // loadSettings behandelt einen negativen horizontalMargin als "nicht gesetzt",
+    // der CoreData-Default des Attributs ist aber 0. Sobald irgendeine Einstellung
+    // gespeichert wurde, existiert die SettingEntity und der Margin kommt als 0
+    // zurück statt als nil - der Reader nutzt dann 0 statt der gewollten 16
+    // (siehe FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
+    @Test("known quirk: an untouched horizontalMargin reads back as 0, not nil")
+    func untouchedHorizontalMarginReadsAsZero() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveSettings(Settings())
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == 0)
+    }
+
+    // MARK: - Card Layout / Tag Sort
+
+    @Test("saveCardLayoutStyle and loadCardLayoutStyle round-trip")
+    func cardLayoutRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveCardLayoutStyle(.compact)
+
+        #expect(try await repository.loadCardLayoutStyle() == .compact)
+    }
+
+    @Test("loadCardLayoutStyle defaults to magazine")
+    func cardLayoutDefault() async throws {
+        let (repository, _) = makeRepository()
+
+        #expect(try await repository.loadCardLayoutStyle() == .magazine)
+    }
+
+    @Test("saveTagSortOrder and loadTagSortOrder round-trip")
+    func tagSortRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveTagSortOrder(.alphabetically)
+
+        #expect(try await repository.loadTagSortOrder() == .alphabetically)
+    }
+
+    // MARK: - Offline Settings
+
+    @Test("offline settings round-trip through CoreData")
+    func offlineSettingsRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+        let syncDate = Date(timeIntervalSince1970: 1_767_225_600)
+
+        try await repository.saveOfflineSettings(
+            OfflineSettings(enabled: true, maxUnreadArticles: 50, saveImages: true, lastSyncDate: syncDate)
+        )
+
+        let loaded = try await repository.loadOfflineSettings()
+        #expect(loaded.enabled == true)
+        #expect(loaded.maxUnreadArticles == 50)
+        #expect(loaded.saveImages == true)
+        #expect(loaded.lastSyncDate == syncDate)
+    }
+
+    @Test("offline settings default to disabled with 20 articles")
+    func offlineSettingsDefaults() async throws {
+        let (repository, _) = makeRepository()
+
+        let loaded = try await repository.loadOfflineSettings()
+
+        #expect(loaded.enabled == false)
+        #expect(loaded.maxUnreadArticles == 20)
+        #expect(loaded.lastSyncDate == nil)
+    }
+
+    // MARK: - UserDefaults-backed
+
+    @Test("hasFinishedSetup is stored in the injected UserDefaults")
+    func hasFinishedSetupUsesInjectedDefaults() async throws {
+        let (repository, defaults) = makeRepository()
+
+        #expect(repository.hasFinishedSetup == false)
+
+        try await repository.saveHasFinishedSetup(true)
+
+        #expect(repository.hasFinishedSetup == true)
+        #expect(defaults.bool(forKey: "hasFinishedSetup") == true)
+    }
+
+    @Test("getMaxCacheSize returns and persists the 200 MB default")
+    func maxCacheSizeDefault() async throws {
+        let (repository, _) = makeRepository()
+
+        let size = try await repository.getMaxCacheSize()
+
+        #expect(size == UInt(200 * 1024 * 1024))
+        // Zweiter Aufruf liest den nun persistierten Wert.
+        #expect(try await repository.getMaxCacheSize() == size)
+    }
+}


### PR DESCRIPTION
41 Tests für den bisher ungetesteten Data-Access-Layer, inklusive DTO→Domain-Assertions (verschachtelte Resources, Page-Metadaten, Detail-Flattening).

Damit die CoreData-gestützten Repositories testbar werden, bekommt `CoreDataManager` einen Init mit vorkonfiguriertem Container, `LabelsRepository` und `SettingsRepository` nehmen ihre Abhängigkeiten per Init mit den bisherigen Singletons als Default. App-Pfad unverändert.

Keychain-Felder in `SettingsRepository` bleiben ausgespart, `KeychainHelper.shared` ist nicht injizierbar und ein Test würde den echten Keychain anfassen.

Verifiziert: 282 Tests grün.

Basiert auf #82 (PR #101).

Closes #83