### PR TITLE
test(urlshare): add a test target and cover the share extension

### DIFF
--- a/URLShare/OfflineBookmarkManager.swift
+++ b/URLShare/OfflineBookmarkManager.swift
@@ -4,12 +4,16 @@ import CoreData
 final class OfflineBookmarkManager: @unchecked Sendable {
     static let shared = OfflineBookmarkManager()
 
-    private init() {}
+    private let coreDataManager: CoreDataManager
+
+    init(coreDataManager: CoreDataManager = .shared) {
+        self.coreDataManager = coreDataManager
+    }
 
     // MARK: - Core Data Stack for Share Extension
 
     var context: NSManagedObjectContext {
-        CoreDataManager.shared.context
+        coreDataManager.context
     }
 
     // MARK: - Offline Storage Methods
@@ -52,7 +56,7 @@ final class OfflineBookmarkManager: @unchecked Sendable {
     }
 
     func getTags() async -> [String] {
-        let backgroundContext = CoreDataManager.shared.newBackgroundContext()
+        let backgroundContext = coreDataManager.newBackgroundContext()
 
         do {
             return try await backgroundContext.perform {
@@ -69,7 +73,7 @@ final class OfflineBookmarkManager: @unchecked Sendable {
     }
 
     func saveTags(_ tags: [String]) async {
-        let backgroundContext = CoreDataManager.shared.newBackgroundContext()
+        let backgroundContext = coreDataManager.newBackgroundContext()
 
         do {
             try await backgroundContext.perform {
@@ -101,7 +105,7 @@ final class OfflineBookmarkManager: @unchecked Sendable {
     }
 
     func saveTagsWithCount(_ tags: [BookmarkLabelDto]) async {
-        let backgroundContext = CoreDataManager.shared.newBackgroundContext()
+        let backgroundContext = coreDataManager.newBackgroundContext()
 
         do {
             try await backgroundContext.perform {

--- a/URLShare/SimpleAPI.swift
+++ b/URLShare/SimpleAPI.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Bündelt die äußeren Abhängigkeiten von `SimpleAPI`, damit die statischen
-/// Methoden testbar bleiben, ohne alle Aufrufer in der Extension anzufassen.
+/// Bundles the outside dependencies of `SimpleAPI` so the static methods stay
+/// testable without having to touch every caller in the extension.
 struct SimpleAPIEnvironment {
     var session: HTTPSession
     var loadToken: () -> String?
@@ -19,7 +19,7 @@ struct SimpleAPIEnvironment {
 final class SimpleAPI {
     private static let logger = Logger.network
 
-    /// In Tests überschreibbar; im App-Betrieb bleibt es bei `live()`.
+    /// Overridable in tests; at runtime this stays on `live()`.
     static var environment = SimpleAPIEnvironment.live()
 
     // MARK: - Token Management

--- a/URLShare/SimpleAPI.swift
+++ b/URLShare/SimpleAPI.swift
@@ -1,7 +1,26 @@
 import Foundation
 
+/// Bündelt die äußeren Abhängigkeiten von `SimpleAPI`, damit die statischen
+/// Methoden testbar bleiben, ohne alle Aufrufer in der Extension anzufassen.
+struct SimpleAPIEnvironment {
+    var session: HTTPSession
+    var loadToken: () -> String?
+    var loadEndpoint: () -> String?
+
+    static func live() -> Self {
+        Self(
+            session: HTTPSessionFactory.makeDefault(),
+            loadToken: { KeychainHelper.shared.loadToken() },
+            loadEndpoint: { KeychainHelper.shared.loadEndpoint() }
+        )
+    }
+}
+
 final class SimpleAPI {
     private static let logger = Logger.network
+
+    /// In Tests überschreibbar; im App-Betrieb bleibt es bei `live()`.
+    static var environment = SimpleAPIEnvironment.live()
 
     // MARK: - Token Management
 
@@ -27,7 +46,7 @@ final class SimpleAPI {
             return oauthToken.accessToken
         }
         // Classic API token authentication
-        return KeychainHelper.shared.loadToken()
+        return environment.loadToken()
     }
 
     private static func willExpireSoon(_ token: OAuthToken) -> Bool {
@@ -40,7 +59,7 @@ final class SimpleAPI {
     private static func refreshOAuthToken() async -> OAuthToken? {
         guard let oauthToken = KeychainHelper.shared.loadOAuthToken(),
               let refreshToken = oauthToken.refreshToken,
-              let endpoint = KeychainHelper.shared.loadEndpoint(),
+              let endpoint = environment.loadEndpoint(),
               let clientId = KeychainHelper.shared.loadOAuthClientId() else {
             logger.error("Missing required data for OAuth token refresh")
             return nil
@@ -65,7 +84,7 @@ final class SimpleAPI {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
             urlRequest.httpBody = formBody.data(using: .utf8)
 
-            let (data, response) = try await URLSession.shared.data(for: urlRequest)
+            let (data, response) = try await environment.session.data(for: urlRequest)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   200...299 ~= httpResponse.statusCode else {
@@ -89,7 +108,7 @@ final class SimpleAPI {
     // MARK: - Server Info
 
     static func checkServerReachability() async -> ServerInfoDto? {
-        guard let endpoint = KeychainHelper.shared.loadEndpoint(),
+        guard let endpoint = environment.loadEndpoint(),
               !endpoint.isEmpty,
               let url = URL(string: "\(endpoint)/api/info") else {
             return nil
@@ -107,7 +126,7 @@ final class SimpleAPI {
         HTTPHeadersHelper.shared.applyCustomHeaders(to: &request)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await environment.session.data(for: request)
             if let httpResponse = response as? HTTPURLResponse,
                200...299 ~= httpResponse.statusCode {
                 logger.info("Server is reachable")
@@ -131,7 +150,7 @@ final class SimpleAPI {
             showStatus("No token found. Please log in via the main app.", true, nil)
             return
         }
-        guard let endpoint = KeychainHelper.shared.loadEndpoint(), !endpoint.isEmpty else {
+        guard let endpoint = environment.loadEndpoint(), !endpoint.isEmpty else {
             showStatus("No server endpoint found.", true, nil)
             return
         }
@@ -151,7 +170,7 @@ final class SimpleAPI {
         HTTPHeadersHelper.shared.applyCustomHeaders(to: &request)
         request.httpBody = requestData
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await environment.session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.error("Invalid server response for bookmark creation")
                 showStatus("Invalid server response.", true, nil)
@@ -211,7 +230,7 @@ final class SimpleAPI {
             showStatus("No token found. Please log in via the main app.", true)
             return nil
         }
-        guard let endpoint = KeychainHelper.shared.loadEndpoint(), !endpoint.isEmpty else {
+        guard let endpoint = environment.loadEndpoint(), !endpoint.isEmpty else {
             showStatus("No server endpoint found.", true)
             return nil
         }
@@ -225,7 +244,7 @@ final class SimpleAPI {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         HTTPHeadersHelper.shared.applyCustomHeaders(to: &request)
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await environment.session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.error("Invalid server response for labels request")
                 showStatus("Invalid server response.", true)

--- a/URLShareTests/OfflineBookmarkManagerTests.swift
+++ b/URLShareTests/OfflineBookmarkManagerTests.swift
@@ -16,18 +16,18 @@ struct OfflineBookmarkManagerTests {
         return (OfflineBookmarkManager(coreDataManager: coreData), coreData)
     }
 
-    private func fetchBookmarks(_ coreData: CoreDataManager) throws -> [ArticleURLEntity] {
+    private func fetchBookmarks(_ coreData: CoreDataManager) async throws -> [ArticleURLEntity] {
         let context = coreData.context
-        return try context.performAndWait {
+        return try await context.perform {
             let request: NSFetchRequest<ArticleURLEntity> = ArticleURLEntity.fetchRequest()
             request.sortDescriptors = [NSSortDescriptor(key: "url", ascending: true)]
             return try context.fetch(request)
         }
     }
 
-    private func fetchTags(_ coreData: CoreDataManager) throws -> [TagEntity] {
+    private func fetchTags(_ coreData: CoreDataManager) async throws -> [TagEntity] {
         let context = coreData.context
-        return try context.performAndWait {
+        return try await context.perform {
             let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
             request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
             return try context.fetch(request)
@@ -37,7 +37,7 @@ struct OfflineBookmarkManagerTests {
     // MARK: - Offline Store
 
     @Test("saveOfflineBookmark queues a bookmark with its tags and HTML")
-    func saveCreatesEntry() throws {
+    func saveCreatesEntry() async throws {
         let (manager, coreData) = makeManager()
 
         let saved = manager.saveOfflineBookmark(
@@ -48,7 +48,7 @@ struct OfflineBookmarkManagerTests {
         )
 
         #expect(saved == true)
-        let entities = try fetchBookmarks(coreData)
+        let entities = try await fetchBookmarks(coreData)
         #expect(entities.count == 1)
         #expect(entities[0].url == "https://example.com/a")
         #expect(entities[0].title == "Article A")
@@ -59,13 +59,13 @@ struct OfflineBookmarkManagerTests {
     }
 
     @Test("saveOfflineBookmark updates the existing entry for a known URL instead of duplicating")
-    func saveDeduplicatesByURL() throws {
+    func saveDeduplicatesByURL() async throws {
         let (manager, coreData) = makeManager()
 
         _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "Old", tags: ["old"], html: "<p>old</p>")
         _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "New", tags: ["new"], html: "<p>new</p>")
 
-        let entities = try fetchBookmarks(coreData)
+        let entities = try await fetchBookmarks(coreData)
         #expect(entities.count == 1)
         #expect(entities[0].title == "New")
         #expect(entities[0].tags == "new")
@@ -73,24 +73,24 @@ struct OfflineBookmarkManagerTests {
     }
 
     @Test("saveOfflineBookmark keeps separate entries for different URLs")
-    func saveKeepsDistinctURLs() throws {
+    func saveKeepsDistinctURLs() async throws {
         let (manager, coreData) = makeManager()
 
         _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "A")
         _ = manager.saveOfflineBookmark(url: "https://example.com/b", title: "B")
 
-        let entities = try fetchBookmarks(coreData)
+        let entities = try await fetchBookmarks(coreData)
         #expect(entities.count == 2)
         #expect(entities.map(\.url) == ["https://example.com/a", "https://example.com/b"])
     }
 
     @Test("saveOfflineBookmark stores empty tags as an empty string")
-    func saveWithoutTags() throws {
+    func saveWithoutTags() async throws {
         let (manager, coreData) = makeManager()
 
         _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "A")
 
-        let entities = try fetchBookmarks(coreData)
+        let entities = try await fetchBookmarks(coreData)
         #expect(entities[0].tags?.isEmpty == true)
         #expect(entities[0].html == nil)
     }
@@ -98,14 +98,14 @@ struct OfflineBookmarkManagerTests {
     // MARK: - Sync Handoff
 
     @Test("a queued bookmark carries everything the sync needs")
-    func queuedEntryIsSyncReady() throws {
+    func queuedEntryIsSyncReady() async throws {
         let (manager, coreData) = makeManager()
 
         _ = manager.saveOfflineBookmark(
             url: "https://example.com/a", title: "A", tags: ["x", "y"], html: "<p>h</p>"
         )
 
-        let entity = try #require(try fetchBookmarks(coreData).first)
+        let entity = try #require(try await fetchBookmarks(coreData).first)
         // Genau diese Felder liest OfflineSyncManager in der Haupt-App aus.
         let tags = entity.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
         #expect(entity.url == "https://example.com/a")
@@ -138,7 +138,7 @@ struct OfflineBookmarkManagerTests {
         await manager.saveTags(["swift", "ios"])
         await manager.saveTags(["swift", "kotlin"])
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.map(\.name) == ["ios", "kotlin", "swift"])
     }
 
@@ -151,7 +151,7 @@ struct OfflineBookmarkManagerTests {
             BookmarkLabelDto(name: "ios", count: 2, href: "/ios")
         ])
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 2)
         #expect(tags.first { $0.name == "swift" }?.count == 5)
         #expect(tags.first { $0.name == "ios" }?.count == 2)
@@ -164,7 +164,7 @@ struct OfflineBookmarkManagerTests {
         await manager.saveTagsWithCount([BookmarkLabelDto(name: "swift", count: 5, href: "/swift")])
         await manager.saveTagsWithCount([BookmarkLabelDto(name: "swift", count: 11, href: "/swift")])
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 1)
         #expect(tags[0].count == 11)
     }

--- a/URLShareTests/OfflineBookmarkManagerTests.swift
+++ b/URLShareTests/OfflineBookmarkManagerTests.swift
@@ -1,0 +1,171 @@
+//
+//  OfflineBookmarkManagerTests.swift
+//  URLShareTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+import CoreData
+
+@Suite("OfflineBookmarkManager Tests")
+struct OfflineBookmarkManagerTests {
+    private func makeManager() -> (OfflineBookmarkManager, CoreDataManager) {
+        let coreData = TestCoreData.makeManager()
+        return (OfflineBookmarkManager(coreDataManager: coreData), coreData)
+    }
+
+    private func fetchBookmarks(_ coreData: CoreDataManager) throws -> [ArticleURLEntity] {
+        let context = coreData.context
+        return try context.performAndWait {
+            let request: NSFetchRequest<ArticleURLEntity> = ArticleURLEntity.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "url", ascending: true)]
+            return try context.fetch(request)
+        }
+    }
+
+    private func fetchTags(_ coreData: CoreDataManager) throws -> [TagEntity] {
+        let context = coreData.context
+        return try context.performAndWait {
+            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+            return try context.fetch(request)
+        }
+    }
+
+    // MARK: - Offline Store
+
+    @Test("saveOfflineBookmark queues a bookmark with its tags and HTML")
+    func saveCreatesEntry() throws {
+        let (manager, coreData) = makeManager()
+
+        let saved = manager.saveOfflineBookmark(
+            url: "https://example.com/a",
+            title: "Article A",
+            tags: ["swift", "ios"],
+            html: "<p>content</p>"
+        )
+
+        #expect(saved == true)
+        let entities = try fetchBookmarks(coreData)
+        #expect(entities.count == 1)
+        #expect(entities[0].url == "https://example.com/a")
+        #expect(entities[0].title == "Article A")
+        // Tags werden als kommaseparierter String abgelegt - so liest sie OfflineSyncManager wieder ein.
+        #expect(entities[0].tags == "swift,ios")
+        #expect(entities[0].html == "<p>content</p>")
+        #expect(entities[0].id != nil)
+    }
+
+    @Test("saveOfflineBookmark updates the existing entry for a known URL instead of duplicating")
+    func saveDeduplicatesByURL() throws {
+        let (manager, coreData) = makeManager()
+
+        _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "Old", tags: ["old"], html: "<p>old</p>")
+        _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "New", tags: ["new"], html: "<p>new</p>")
+
+        let entities = try fetchBookmarks(coreData)
+        #expect(entities.count == 1)
+        #expect(entities[0].title == "New")
+        #expect(entities[0].tags == "new")
+        #expect(entities[0].html == "<p>new</p>")
+    }
+
+    @Test("saveOfflineBookmark keeps separate entries for different URLs")
+    func saveKeepsDistinctURLs() throws {
+        let (manager, coreData) = makeManager()
+
+        _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "A")
+        _ = manager.saveOfflineBookmark(url: "https://example.com/b", title: "B")
+
+        let entities = try fetchBookmarks(coreData)
+        #expect(entities.count == 2)
+        #expect(entities.map(\.url) == ["https://example.com/a", "https://example.com/b"])
+    }
+
+    @Test("saveOfflineBookmark stores empty tags as an empty string")
+    func saveWithoutTags() throws {
+        let (manager, coreData) = makeManager()
+
+        _ = manager.saveOfflineBookmark(url: "https://example.com/a", title: "A")
+
+        let entities = try fetchBookmarks(coreData)
+        #expect(entities[0].tags?.isEmpty == true)
+        #expect(entities[0].html == nil)
+    }
+
+    // MARK: - Sync Handoff
+
+    @Test("a queued bookmark carries everything the sync needs")
+    func queuedEntryIsSyncReady() throws {
+        let (manager, coreData) = makeManager()
+
+        _ = manager.saveOfflineBookmark(
+            url: "https://example.com/a", title: "A", tags: ["x", "y"], html: "<p>h</p>"
+        )
+
+        let entity = try #require(try fetchBookmarks(coreData).first)
+        // Genau diese Felder liest OfflineSyncManager in der Haupt-App aus.
+        let tags = entity.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
+        #expect(entity.url == "https://example.com/a")
+        #expect(tags == ["x", "y"])
+        #expect(entity.html == "<p>h</p>")
+    }
+
+    // MARK: - Tags
+
+    @Test("getTags returns the stored tag names sorted")
+    func getTagsSorted() async throws {
+        let (manager, _) = makeManager()
+
+        await manager.saveTags(["swift", "android", "ios"])
+
+        #expect(await manager.getTags() == ["android", "ios", "swift"])
+    }
+
+    @Test("getTags is empty when nothing is stored")
+    func getTagsEmpty() async throws {
+        let (manager, _) = makeManager()
+
+        #expect(await manager.getTags().isEmpty)
+    }
+
+    @Test("saveTags does not insert duplicates")
+    func saveTagsDeduplicates() async throws {
+        let (manager, coreData) = makeManager()
+
+        await manager.saveTags(["swift", "ios"])
+        await manager.saveTags(["swift", "kotlin"])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.map(\.name) == ["ios", "kotlin", "swift"])
+    }
+
+    @Test("saveTagsWithCount inserts new tags with their counts")
+    func saveTagsWithCountInserts() async throws {
+        let (manager, coreData) = makeManager()
+
+        await manager.saveTagsWithCount([
+            BookmarkLabelDto(name: "swift", count: 5, href: "/swift"),
+            BookmarkLabelDto(name: "ios", count: 2, href: "/ios")
+        ])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 2)
+        #expect(tags.first { $0.name == "swift" }?.count == 5)
+        #expect(tags.first { $0.name == "ios" }?.count == 2)
+    }
+
+    @Test("saveTagsWithCount updates the count of a known tag")
+    func saveTagsWithCountUpdates() async throws {
+        let (manager, coreData) = makeManager()
+
+        await manager.saveTagsWithCount([BookmarkLabelDto(name: "swift", count: 5, href: "/swift")])
+        await manager.saveTagsWithCount([BookmarkLabelDto(name: "swift", count: 11, href: "/swift")])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags[0].count == 11)
+    }
+}

--- a/URLShareTests/OfflineBookmarkManagerTests.swift
+++ b/URLShareTests/OfflineBookmarkManagerTests.swift
@@ -52,7 +52,7 @@ struct OfflineBookmarkManagerTests {
         #expect(entities.count == 1)
         #expect(entities[0].url == "https://example.com/a")
         #expect(entities[0].title == "Article A")
-        // Tags werden als kommaseparierter String abgelegt - so liest sie OfflineSyncManager wieder ein.
+        // Tags are stored as a comma-separated string, which is how OfflineSyncManager reads them back.
         #expect(entities[0].tags == "swift,ios")
         #expect(entities[0].html == "<p>content</p>")
         #expect(entities[0].id != nil)
@@ -106,7 +106,7 @@ struct OfflineBookmarkManagerTests {
         )
 
         let entity = try #require(try await fetchBookmarks(coreData).first)
-        // Genau diese Felder liest OfflineSyncManager in der Haupt-App aus.
+        // These are exactly the fields OfflineSyncManager reads in the main app.
         let tags = entity.tags?.components(separatedBy: ",").filter { !$0.isEmpty } ?? []
         #expect(entity.url == "https://example.com/a")
         #expect(tags == ["x", "y"])

--- a/URLShareTests/ShareExtensionTestSupport.swift
+++ b/URLShareTests/ShareExtensionTestSupport.swift
@@ -8,8 +8,8 @@
 import Foundation
 import CoreData
 
-/// HTTPSession-Mock für die Share-Extension-Tests.
-/// Eigene Kopie, weil `readeckTests` ein anderes Modul ist.
+/// HTTPSession mock for the share extension tests.
+/// A separate copy, because `readeckTests` is a different module.
 final class MockHTTPSession: HTTPSession, @unchecked Sendable {
     enum Stub {
         case http(status: Int, data: Data, headers: [String: String] = [:])
@@ -62,12 +62,12 @@ extension MockHTTPSession.Stub {
 // MARK: - In-Memory CoreData
 
 enum TestCoreData {
-    /// Ein gemeinsames Modell für alle Stores: mehrere `mergedModel`-Instanzen
-    /// beanspruchen sonst dieselbe NSManagedObject-Subklasse und CoreData
-    /// kann `+entity` nicht mehr auflösen.
+    /// One model shared by every store: several `mergedModel` instances would each
+    /// claim the same NSManagedObject subclass, and CoreData could no longer resolve
+    /// `+entity`.
     ///
-    /// Das Modell wird aus dem Test-Bundle geladen, nicht aus `Bundle.main`:
-    /// URLShareTests läuft ohne Host-App, `Bundle.main` ist dort das xctest-Tool.
+    /// The model is loaded from the test bundle rather than `Bundle.main`:
+    /// URLShareTests runs without a host app, where `Bundle.main` is the xctest tool.
     static let model: NSManagedObjectModel = {
         let bundle = Bundle(for: MockHTTPSession.self)
         guard let model = NSManagedObjectModel.mergedModel(from: [bundle]) else {

--- a/URLShareTests/ShareExtensionTestSupport.swift
+++ b/URLShareTests/ShareExtensionTestSupport.swift
@@ -1,0 +1,110 @@
+//
+//  ShareExtensionTestSupport.swift
+//  URLShareTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Foundation
+import CoreData
+
+/// HTTPSession-Mock für die Share-Extension-Tests.
+/// Eigene Kopie, weil `readeckTests` ein anderes Modul ist.
+final class MockHTTPSession: HTTPSession, @unchecked Sendable {
+    enum Stub {
+        case http(status: Int, data: Data, headers: [String: String] = [:])
+        case failure(Error)
+    }
+
+    var stubs: [Stub]
+    private(set) var requests: [URLRequest] = []
+    private var index = 0
+
+    init(_ stubs: [Stub]) {
+        self.stubs = stubs
+    }
+
+    convenience init(_ stub: Stub) {
+        self.init([stub])
+    }
+
+    var lastRequest: URLRequest? { requests.last }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+
+        guard let stub = index < stubs.count ? stubs[index] : stubs.last else {
+            throw URLError(.unsupportedURL)
+        }
+        index += 1
+
+        switch stub {
+        case let .http(status, data, headers):
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://mock.example.com")!,
+                statusCode: status,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+            )!
+            return (data, response)
+        case let .failure(error):
+            throw error
+        }
+    }
+}
+
+extension MockHTTPSession.Stub {
+    static func json(_ json: String, status: Int = 200, headers: [String: String] = [:]) -> MockHTTPSession.Stub {
+        .http(status: status, data: Data(json.utf8), headers: headers)
+    }
+}
+
+// MARK: - In-Memory CoreData
+
+enum TestCoreData {
+    /// Ein gemeinsames Modell für alle Stores: mehrere `mergedModel`-Instanzen
+    /// beanspruchen sonst dieselbe NSManagedObject-Subklasse und CoreData
+    /// kann `+entity` nicht mehr auflösen.
+    ///
+    /// Das Modell wird aus dem Test-Bundle geladen, nicht aus `Bundle.main`:
+    /// URLShareTests läuft ohne Host-App, `Bundle.main` ist dort das xctest-Tool.
+    static let model: NSManagedObjectModel = {
+        let bundle = Bundle(for: MockHTTPSession.self)
+        guard let model = NSManagedObjectModel.mergedModel(from: [bundle]) else {
+            preconditionFailure("CoreData model not found in the URLShareTests bundle")
+        }
+        return model
+    }()
+
+    static func makeManager() -> CoreDataManager {
+        let container = NSPersistentContainer(name: "readeck", managedObjectModel: model)
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+
+        container.loadPersistentStores { _, error in
+            precondition(error == nil, "In-memory store failed to load: \(String(describing: error))")
+        }
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        return CoreDataManager(container: container)
+    }
+}
+
+// MARK: - SimpleAPI Environment
+
+extension SimpleAPIEnvironment {
+    static func test(
+        session: HTTPSession,
+        token: String? = "test-token",
+        endpoint: String? = "https://mock.example.com"
+    ) -> SimpleAPIEnvironment {
+        SimpleAPIEnvironment(
+            session: session,
+            loadToken: { token },
+            loadEndpoint: { endpoint }
+        )
+    }
+}

--- a/URLShareTests/SimpleAPITests.swift
+++ b/URLShareTests/SimpleAPITests.swift
@@ -1,0 +1,174 @@
+//
+//  SimpleAPITests.swift
+//  URLShareTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+
+/// `SimpleAPI` ist bewusst statisch, daher wird die Umgebung pro Test gesetzt
+/// und danach wieder auf `live()` zurückgestellt.
+@Suite("SimpleAPI Tests", .serialized)
+struct SimpleAPITests {
+    private func withEnvironment(
+        _ environment: SimpleAPIEnvironment,
+        _ body: () async throws -> Void
+    ) async rethrows {
+        SimpleAPI.environment = environment
+        defer { SimpleAPI.environment = .live() }
+        try await body()
+    }
+
+    // MARK: - Server Reachability
+
+    @Test("checkServerReachability decodes the server info when reachable")
+    func serverReachable() async throws {
+        let session = MockHTTPSession(.json(#"{"version": {"canonical": "0.22.0"}}"#))
+
+        await withEnvironment(.test(session: session)) {
+            let info = await SimpleAPI.checkServerReachability()
+
+            #expect(info?.version.canonical == "0.22.0")
+            #expect(info?.supportsHTMLBookmarks == true)
+            #expect(session.lastRequest?.url?.absoluteString == "https://mock.example.com/api/info")
+        }
+    }
+
+    @Test("checkServerReachability returns nil when the server is unreachable")
+    func serverUnreachable() async throws {
+        let session = MockHTTPSession(.failure(URLError(.cannotConnectToHost)))
+
+        await withEnvironment(.test(session: session)) {
+            #expect(await SimpleAPI.checkServerReachability() == nil)
+        }
+    }
+
+    @Test("checkServerReachability returns nil on a server error")
+    func serverReturnsError() async throws {
+        let session = MockHTTPSession(.http(status: 500, data: Data()))
+
+        await withEnvironment(.test(session: session)) {
+            #expect(await SimpleAPI.checkServerReachability() == nil)
+        }
+    }
+
+    @Test("checkServerReachability returns nil without a configured endpoint")
+    func serverWithoutEndpoint() async throws {
+        let session = MockHTTPSession(.json("{}"))
+
+        await withEnvironment(.test(session: session, endpoint: nil)) {
+            #expect(await SimpleAPI.checkServerReachability() == nil)
+            #expect(session.requests.isEmpty)
+        }
+    }
+
+    @Test("an older server does not advertise HTML bookmark support")
+    func oldServerLacksHTMLSupport() async throws {
+        let session = MockHTTPSession(.json(#"{"version": {"canonical": "0.21.9"}}"#))
+
+        await withEnvironment(.test(session: session)) {
+            let info = await SimpleAPI.checkServerReachability()
+            #expect(info?.supportsHTMLBookmarks == false)
+        }
+    }
+
+    // MARK: - addBookmark
+
+    @Test("addBookmark reports success and extracts the id from the Bookmark-Id header")
+    func addBookmarkSuccess() async throws {
+        let session = MockHTTPSession(
+            .json(#"{"message": "created", "status": 0}"#, headers: ["Bookmark-Id": "bm-42"])
+        )
+
+        await withEnvironment(.test(session: session)) {
+            var result: (message: String, isError: Bool, id: String?)?
+            await SimpleAPI.addBookmark(title: "T", url: "https://example.com/a", labels: ["swift"]) {
+                result = ($0, $1, $2)
+            }
+
+            #expect(result?.isError == false)
+            #expect(result?.id == "bm-42")
+            #expect(session.lastRequest?.url?.absoluteString == "https://mock.example.com/api/bookmarks")
+            #expect(session.lastRequest?.httpMethod == "POST")
+            #expect(session.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+        }
+    }
+
+    @Test("addBookmark falls back to the Location header for the id")
+    func addBookmarkIdFromLocation() async throws {
+        let session = MockHTTPSession(
+            .json(#"{"message": "created", "status": 0}"#, headers: ["Location": "/api/bookmarks/bm-7"])
+        )
+
+        await withEnvironment(.test(session: session)) {
+            var id: String?
+            await SimpleAPI.addBookmark(title: "T", url: "https://example.com/a") { _, _, bookmarkId in
+                id = bookmarkId
+            }
+            #expect(id == "bm-7")
+        }
+    }
+
+    @Test("addBookmark sends the request body with url, title and labels")
+    func addBookmarkSendsBody() async throws {
+        let session = MockHTTPSession(.json(#"{"message": "created", "status": 0}"#))
+
+        await withEnvironment(.test(session: session)) {
+            await SimpleAPI.addBookmark(title: "Title", url: "https://example.com/a", labels: ["x"]) { _, _, _ in }
+
+            let body = try! #require(session.lastRequest?.httpBody)
+            let decoded = try! JSONDecoder().decode(CreateBookmarkRequestDto.self, from: body)
+            #expect(decoded.url == "https://example.com/a")
+            #expect(decoded.title == "Title")
+            #expect(decoded.labels == ["x"])
+        }
+    }
+
+    @Test("addBookmark reports a network error instead of throwing")
+    func addBookmarkNetworkError() async throws {
+        let session = MockHTTPSession(.failure(URLError(.notConnectedToInternet)))
+
+        await withEnvironment(.test(session: session)) {
+            var result: (message: String, isError: Bool)?
+            await SimpleAPI.addBookmark(title: "T", url: "https://example.com/a") { message, isError, _ in
+                result = (message, isError)
+            }
+
+            #expect(result?.isError == true)
+            #expect(result?.message.contains("Network error") == true)
+        }
+    }
+
+    @Test("addBookmark surfaces a 401 as an expired session")
+    func addBookmarkUnauthorized() async throws {
+        let session = MockHTTPSession(.http(status: 401, data: Data()))
+
+        await withEnvironment(.test(session: session)) {
+            var result: (message: String, isError: Bool)?
+            await SimpleAPI.addBookmark(title: "T", url: "https://example.com/a") { message, isError, _ in
+                result = (message, isError)
+            }
+
+            #expect(result?.isError == true)
+            #expect(result?.message.contains("Session expired") == true)
+        }
+    }
+
+    @Test("addBookmark reports a missing token without hitting the network")
+    func addBookmarkWithoutToken() async throws {
+        let session = MockHTTPSession(.json("{}"))
+
+        await withEnvironment(.test(session: session, token: nil)) {
+            var result: (message: String, isError: Bool)?
+            await SimpleAPI.addBookmark(title: "T", url: "https://example.com/a") { message, isError, _ in
+                result = (message, isError)
+            }
+
+            #expect(result?.isError == true)
+            #expect(result?.message.contains("No token found") == true)
+            #expect(session.requests.isEmpty)
+        }
+    }
+}

--- a/URLShareTests/SimpleAPITests.swift
+++ b/URLShareTests/SimpleAPITests.swift
@@ -8,8 +8,8 @@
 import Testing
 import Foundation
 
-/// `SimpleAPI` ist bewusst statisch, daher wird die Umgebung pro Test gesetzt
-/// und danach wieder auf `live()` zurückgestellt.
+/// `SimpleAPI` is static by design, so the environment is set per test and
+/// restored to `live()` afterwards.
 @Suite("SimpleAPI Tests", .serialized)
 struct SimpleAPITests {
     private func withEnvironment(

--- a/URLShareTests/TagRepositoryTests.swift
+++ b/URLShareTests/TagRepositoryTests.swift
@@ -1,0 +1,67 @@
+//
+//  TagRepositoryTests.swift
+//  URLShareTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+import CoreData
+
+@Suite("TagRepository Tests")
+struct TagRepositoryTests {
+    private func fetchTags(_ context: NSManagedObjectContext) throws -> [TagEntity] {
+        try context.performAndWait {
+            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+            return try context.fetch(request)
+        }
+    }
+
+    @Test("saveNewLabel creates a label with count 1")
+    func createsLabel() throws {
+        let context = TestCoreData.makeManager().context
+        let repository = TagRepository()
+
+        repository.saveNewLabel(name: "swift", context: context)
+
+        let tags = try fetchTags(context)
+        #expect(tags.count == 1)
+        #expect(tags[0].name == "swift")
+        #expect(tags[0].count == 1)
+    }
+
+    @Test("saveNewLabel does not create a duplicate")
+    func deduplicates() throws {
+        let context = TestCoreData.makeManager().context
+        let repository = TagRepository()
+
+        repository.saveNewLabel(name: "swift", context: context)
+        repository.saveNewLabel(name: "swift", context: context)
+
+        #expect(try fetchTags(context).count == 1)
+    }
+
+    @Test("saveNewLabel trims surrounding whitespace")
+    func trimsWhitespace() throws {
+        let context = TestCoreData.makeManager().context
+        let repository = TagRepository()
+
+        repository.saveNewLabel(name: "  swift \n", context: context)
+
+        let tags = try fetchTags(context)
+        #expect(tags.count == 1)
+        #expect(tags[0].name == "swift")
+    }
+
+    @Test("saveNewLabel ignores blank names", arguments: ["", "   ", "\n"])
+    func ignoresBlank(name: String) throws {
+        let context = TestCoreData.makeManager().context
+        let repository = TagRepository()
+
+        repository.saveNewLabel(name: name, context: context)
+
+        #expect(try fetchTags(context).isEmpty)
+    }
+}

--- a/URLShareTests/TagRepositoryTests.swift
+++ b/URLShareTests/TagRepositoryTests.swift
@@ -11,8 +11,8 @@ import CoreData
 
 @Suite("TagRepository Tests")
 struct TagRepositoryTests {
-    private func fetchTags(_ context: NSManagedObjectContext) throws -> [TagEntity] {
-        try context.performAndWait {
+    private func fetchTags(_ context: NSManagedObjectContext) async throws -> [TagEntity] {
+        try await context.perform {
             let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
             request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
             return try context.fetch(request)
@@ -20,48 +20,48 @@ struct TagRepositoryTests {
     }
 
     @Test("saveNewLabel creates a label with count 1")
-    func createsLabel() throws {
+    func createsLabel() async throws {
         let context = TestCoreData.makeManager().context
         let repository = TagRepository()
 
         repository.saveNewLabel(name: "swift", context: context)
 
-        let tags = try fetchTags(context)
+        let tags = try await fetchTags(context)
         #expect(tags.count == 1)
         #expect(tags[0].name == "swift")
         #expect(tags[0].count == 1)
     }
 
     @Test("saveNewLabel does not create a duplicate")
-    func deduplicates() throws {
+    func deduplicates() async throws {
         let context = TestCoreData.makeManager().context
         let repository = TagRepository()
 
         repository.saveNewLabel(name: "swift", context: context)
         repository.saveNewLabel(name: "swift", context: context)
 
-        #expect(try fetchTags(context).count == 1)
+        #expect(try await fetchTags(context).count == 1)
     }
 
     @Test("saveNewLabel trims surrounding whitespace")
-    func trimsWhitespace() throws {
+    func trimsWhitespace() async throws {
         let context = TestCoreData.makeManager().context
         let repository = TagRepository()
 
         repository.saveNewLabel(name: "  swift \n", context: context)
 
-        let tags = try fetchTags(context)
+        let tags = try await fetchTags(context)
         #expect(tags.count == 1)
         #expect(tags[0].name == "swift")
     }
 
     @Test("saveNewLabel ignores blank names", arguments: ["", "   ", "\n"])
-    func ignoresBlank(name: String) throws {
+    func ignoresBlank(name: String) async throws {
         let context = TestCoreData.makeManager().context
         let repository = TagRepository()
 
         repository.saveNewLabel(name: name, context: context)
 
-        #expect(try fetchTags(context).isEmpty)
+        #expect(try await fetchTags(context).isEmpty)
     }
 }

--- a/readeck.xcodeproj/project.pbxproj
+++ b/readeck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		103C17BBCFB084472615B905 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0C0D569DFD3B5483557CD50 /* Foundation.framework */; };
 		5D2B7FB92DFA27A400EBDB2B /* URLShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5D2B7FAF2DFA27A400EBDB2B /* URLShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5D348CC32E0C9F4F00D0AF21 /* netfox in Frameworks */ = {isa = PBXBuildFile; productRef = 5D348CC22E0C9F4F00D0AF21 /* netfox */; };
 		5D48E6022EB402F50043F90F /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5D48E6012EB402F50043F90F /* MarkdownUI */; };
@@ -69,9 +70,22 @@
 		5D45F9C82DF858680048D5B8 /* readeck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = readeck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D45F9DE2DF8586A0048D5B8 /* readeckTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = readeckTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D45F9E82DF8586A0048D5B8 /* readeckUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = readeckUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6D21C83CCC049BB1E7E1CA7 /* URLShareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLShareTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0C0D569DFD3B5483557CD50 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		004F78962C51C3A61A09A657 /* Exceptions for "URLShare" folder in "URLShareTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				OfflineBookmarkManager.swift,
+				ShareExtensionServerCheck.swift,
+				SimpleAPI.swift,
+				SimpleAPIDTOs.swift,
+				TagRepository.swift,
+			);
+			target = CBCF65D6F1178F453B97EB43 /* URLShareTests */;
+		};
 		5D2B7FBA2DFA27A400EBDB2B /* Exceptions for "URLShare" folder in "URLShare" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -84,6 +98,7 @@
 			membershipExceptions = (
 				Assets.xcassets,
 				Data/API/DTOs/OAuthTokenResponseDto.swift,
+				Data/API/HTTPSession.swift,
 				Data/CoreData/CoreDataManager.swift,
 				"Data/Extensions/NSManagedObjectContext+SafeFetch.swift",
 				"Data/Extensions/String+Localization.swift",
@@ -128,6 +143,49 @@
 			);
 			target = 5D45F9C72DF858680048D5B8 /* readeck */;
 		};
+		9000F8C7CACD096CE2F73779 /* Exceptions for "readeck" folder in "URLShareTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Assets.xcassets,
+				Data/API/DTOs/OAuthTokenResponseDto.swift,
+				Data/API/HTTPSession.swift,
+				Data/CoreData/CoreDataManager.swift,
+				"Data/Extensions/NSManagedObjectContext+SafeFetch.swift",
+				"Data/Extensions/String+Localization.swift",
+				Data/KeychainHelper.swift,
+				Data/Utils/HTTPHeadersHelper.swift,
+				Data/Utils/LabelUtils.swift,
+				Domain/Model/ArchiveAdvanceMode.swift,
+				Domain/Model/Bookmark.swift,
+				Domain/Model/BookmarkLabel.swift,
+				Domain/Model/BookmarkSortSettings.swift,
+				Domain/Model/CardLayoutStyle.swift,
+				Domain/Model/FontFamily.swift,
+				Domain/Model/FontSize.swift,
+				Domain/Model/ReaderColorTheme.swift,
+				Domain/Model/Settings.swift,
+				Domain/Model/SwipeAction.swift,
+				Domain/Model/TagSortOrder.swift,
+				Domain/Model/Theme.swift,
+				Domain/Model/UrlOpener.swift,
+				Domain/Models/AuthenticationMethod.swift,
+				Domain/Models/OAuthToken.swift,
+				readeck.xcdatamodeld,
+				Splash.storyboard,
+				UI/Components/Constants.swift,
+				UI/Components/CoreDataTagManagementView.swift,
+				UI/Components/CustomTextFieldStyle.swift,
+				UI/Components/LegacyTagManagementView.swift,
+				UI/Components/UnifiedLabelChip.swift,
+				UI/Extension/FontSizeExtension.swift,
+				UI/Models/AppSettings.swift,
+				UI/Utils/BuildEnvironment.swift,
+				UI/Utils/Logger.swift,
+				UI/Utils/LogStore.swift,
+				UI/Utils/NotificationNames.swift,
+			);
+			target = CBCF65D6F1178F453B97EB43 /* URLShareTests */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -135,6 +193,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				5D2B7FBA2DFA27A400EBDB2B /* Exceptions for "URLShare" folder in "URLShare" target */,
+				004F78962C51C3A61A09A657 /* Exceptions for "URLShare" folder in "URLShareTests" target */,
 			);
 			path = URLShare;
 			sourceTree = "<group>";
@@ -144,6 +203,7 @@
 			exceptions = (
 				5DCD48BE2DFB47A800AC7FB6 /* Exceptions for "readeck" folder in "readeck" target */,
 				5DCD48B72DFB44D600AC7FB6 /* Exceptions for "readeck" folder in "URLShare" target */,
+				9000F8C7CACD096CE2F73779 /* Exceptions for "readeck" folder in "URLShareTests" target */,
 			);
 			path = readeck;
 			sourceTree = "<group>";
@@ -156,6 +216,11 @@
 		5D45F9EB2DF8586A0048D5B8 /* readeckUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = readeckUITests;
+			sourceTree = "<group>";
+		};
+		C8442F1795FF22F013BE0B9B /* URLShareTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = URLShareTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -195,9 +260,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE655A2EFB36EA440CAB383C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				103C17BBCFB084472615B905 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2820DCFB2849BA9228F3891D /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				D0C0D569DFD3B5483557CD50 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		377752A5ABDC44A73B21F1B9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2820DCFB2849BA9228F3891D /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		5D45F9BF2DF858680048D5B8 = {
 			isa = PBXGroup;
 			children = (
@@ -206,6 +295,8 @@
 				5D45F9EB2DF8586A0048D5B8 /* readeckUITests */,
 				5D2B7FB02DFA27A400EBDB2B /* URLShare */,
 				5D45F9C92DF858680048D5B8 /* Products */,
+				377752A5ABDC44A73B21F1B9 /* Frameworks */,
+				C8442F1795FF22F013BE0B9B /* URLShareTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -216,6 +307,7 @@
 				5D45F9DE2DF8586A0048D5B8 /* readeckTests.xctest */,
 				5D45F9E82DF8586A0048D5B8 /* readeckUITests.xctest */,
 				5D2B7FAF2DFA27A400EBDB2B /* URLShare.appex */,
+				B6D21C83CCC049BB1E7E1CA7 /* URLShareTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -239,8 +331,6 @@
 				5D2B7FB02DFA27A400EBDB2B /* URLShare */,
 			);
 			name = URLShare;
-			packageProductDependencies = (
-			);
 			productName = URLShare;
 			productReference = 5D2B7FAF2DFA27A400EBDB2B /* URLShare.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -295,8 +385,6 @@
 				5D45F9E12DF8586A0048D5B8 /* readeckTests */,
 			);
 			name = readeckTests;
-			packageProductDependencies = (
-			);
 			productName = readeckTests;
 			productReference = 5D45F9DE2DF8586A0048D5B8 /* readeckTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -318,11 +406,29 @@
 				5D45F9EB2DF8586A0048D5B8 /* readeckUITests */,
 			);
 			name = readeckUITests;
-			packageProductDependencies = (
-			);
 			productName = readeckUITests;
 			productReference = 5D45F9E82DF8586A0048D5B8 /* readeckUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		CBCF65D6F1178F453B97EB43 /* URLShareTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67AE5D586EE73295D4B99E70 /* Build configuration list for PBXNativeTarget "URLShareTests" */;
+			buildPhases = (
+				112A90A2B4FDC6FCEFF59622 /* Sources */,
+				DE655A2EFB36EA440CAB383C /* Frameworks */,
+				7E8893E00576BF44CD4C50D1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C8442F1795FF22F013BE0B9B /* URLShareTests */,
+			);
+			name = URLShareTests;
+			productName = URLShareTests;
+			productReference = B6D21C83CCC049BB1E7E1CA7 /* URLShareTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -376,6 +482,7 @@
 				5D45F9DD2DF8586A0048D5B8 /* readeckTests */,
 				5D45F9E72DF8586A0048D5B8 /* readeckUITests */,
 				5D2B7FAE2DFA27A400EBDB2B /* URLShare */,
+				CBCF65D6F1178F453B97EB43 /* URLShareTests */,
 			);
 		};
 /* End PBXProject section */
@@ -409,6 +516,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7E8893E00576BF44CD4C50D1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -434,6 +548,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		112A90A2B4FDC6FCEFF59622 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5D2B7FAB2DFA27A400EBDB2B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -854,6 +975,39 @@
 			};
 			name = Release;
 		};
+		923BC3116D37E441E48DFFB5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8J69P655GN;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				PRODUCT_BUNDLE_IDENTIFIER = de.ilyashallak.URLShareTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Debug;
+		};
+		B9B64A5EAD53EB2E0EE9FE9F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8J69P655GN;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				PRODUCT_BUNDLE_IDENTIFIER = de.ilyashallak.URLShareTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -898,6 +1052,15 @@
 			buildConfigurations = (
 				5D45F9F92DF8586A0048D5B8 /* Debug */,
 				5D45F9FA2DF8586A0048D5B8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67AE5D586EE73295D4B99E70 /* Build configuration list for PBXNativeTarget "URLShareTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9B64A5EAD53EB2E0EE9FE9F /* Release */,
+				923BC3116D37E441E48DFFB5 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
+++ b/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
@@ -42,8 +42,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D45F9E72DF8586A0048D5B8"

--- a/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
+++ b/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
@@ -32,7 +32,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D45F9DD2DF8586A0048D5B8"
@@ -43,7 +43,7 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5D45F9E72DF8586A0048D5B8"
@@ -54,7 +54,7 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CBCF65D6F1178F453B97EB43"

--- a/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
+++ b/readeck.xcodeproj/xcshareddata/xcschemes/readeck.xcscheme
@@ -52,6 +52,17 @@
                ReferencedContainer = "container:readeck.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBCF65D6F1178F453B97EB43"
+               BuildableName = "URLShareTests.xctest"
+               BlueprintName = "URLShareTests"
+               ReferencedContainer = "container:readeck.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/readeck/Data/API/HTTPSession.swift
+++ b/readeck/Data/API/HTTPSession.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-/// Schmale Abstraktion über die eine URLSession-Methode, die die App tatsächlich nutzt.
-/// `URLSession` erfüllt die Signatur bereits nativ, dadurch bleibt die Extension leer.
-/// In Tests lässt sich ein einfacher Mock injizieren, ohne URLProtocol-Setup.
+/// Slim abstraction over the one URLSession method the app actually uses.
+/// `URLSession` already satisfies the signature natively, so the extension stays empty.
+/// Tests can inject a simple mock without any URLProtocol setup.
 protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)
 }
@@ -17,13 +17,13 @@ protocol HTTPSession {
 extension URLSession: HTTPSession {}
 
 enum HTTPSessionFactory {
-    /// Default-Session mit konfigurierten Timeouts für self-hosted / langsame Server.
-    /// Der 60s-Default fühlt sich sonst wie ein Freeze an.
+    /// Default session with timeouts tuned for self-hosted / slow servers.
+    /// The 60s default otherwise feels like a freeze.
     ///
-    /// `waitsForConnectivity` bleibt bewusst aus: OfflineSyncManager erkennt einen
-    /// nicht erreichbaren Server an URLError-Codes wie `.notConnectedToInternet` und
-    /// bricht den Sync dann früh ab. Mit Warten käme stattdessen erst nach
-    /// `timeoutIntervalForResource` ein `.timedOut`, und die Offline-Erkennung liefe ins Leere.
+    /// `waitsForConnectivity` is deliberately left off: OfflineSyncManager detects an
+    /// unreachable server through URLError codes such as `.notConnectedToInternet` and
+    /// aborts the sync early. Waiting would surface a `.timedOut` only after
+    /// `timeoutIntervalForResource`, and that offline detection would silently stop working.
     static func makeDefault() -> HTTPSession {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30

--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -6,10 +6,23 @@ final class CoreDataManager {
 
     private var isInMemoryStore = false
     private let logger = Logger.data
+    private let injectedContainer: NSPersistentContainer?
 
-    private init() {}
+    private init() {
+        self.injectedContainer = nil
+    }
+
+    /// Erlaubt einen vorkonfigurierten Container, etwa einen In-Memory-Store in Tests.
+    /// Der reguläre App-Pfad läuft weiter über `shared`.
+    init(container: NSPersistentContainer) {
+        self.injectedContainer = container
+    }
 
     lazy var persistentContainer: NSPersistentContainer = {
+        if let injectedContainer {
+            return injectedContainer
+        }
+
         // Try to find the model in the main bundle first, then in extension bundle
         guard let modelURL = Bundle.main.url(forResource: "readeck", withExtension: "momd") ??
                              Bundle(for: CoreDataManager.self).url(forResource: "readeck", withExtension: "momd") else {

--- a/readeck/Data/CoreData/CoreDataManager.swift
+++ b/readeck/Data/CoreData/CoreDataManager.swift
@@ -12,8 +12,8 @@ final class CoreDataManager {
         self.injectedContainer = nil
     }
 
-    /// Erlaubt einen vorkonfigurierten Container, etwa einen In-Memory-Store in Tests.
-    /// Der reguläre App-Pfad läuft weiter über `shared`.
+    /// Accepts a preconfigured container, e.g. an in-memory store in tests.
+    /// The regular app path keeps going through `shared`.
     init(container: NSPersistentContainer) {
         self.injectedContainer = container
     }

--- a/readeck/Data/Repository/LabelsRepository.swift
+++ b/readeck/Data/Repository/LabelsRepository.swift
@@ -4,10 +4,11 @@ import CoreData
 final class LabelsRepository: PLabelsRepository, @unchecked Sendable {
     private let api: PAPI
 
-    private let coreDataManager = CoreDataManager.shared
+    private let coreDataManager: CoreDataManager
 
-    init(api: PAPI) {
+    init(api: PAPI, coreDataManager: CoreDataManager = .shared) {
         self.api = api
+        self.coreDataManager = coreDataManager
     }
 
     func getLabels() async throws -> [BookmarkLabel] {

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -3,13 +3,19 @@ import CoreData
 import Kingfisher
 
 final class SettingsRepository: PSettingsRepository {
-    private let coreDataManager = CoreDataManager.shared
-    private let userDefault = UserDefaults.standard
+    private let coreDataManager: CoreDataManager
+    private let userDefault: UserDefaults
     private let keychainHelper = KeychainHelper.shared
     private let tokenProvider: TokenProvider
 
-    init(tokenProvider: TokenProvider = KeychainTokenProvider()) {
+    init(
+        tokenProvider: TokenProvider = KeychainTokenProvider(),
+        coreDataManager: CoreDataManager = .shared,
+        userDefaults: UserDefaults = .standard
+    ) {
         self.tokenProvider = tokenProvider
+        self.coreDataManager = coreDataManager
+        self.userDefault = userDefaults
     }
 
     var hasFinishedSetup: Bool {

--- a/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
+++ b/readeckTests/API/BookmarkArticleRecoveryAPITests.swift
@@ -65,9 +65,9 @@ final class BookmarkArticleRecoveryAPITests: XCTestCase {
         super.tearDown()
     }
 
-    /// API mit einer Session, deren Requests über das Stub-URLProtocol laufen.
-    /// `protocolClasses` in der Konfiguration greift auch bei einer injizierten
-    /// Session - im Gegensatz zu global registrierten Klassen, die nur `URLSession.shared` treffen.
+    /// API backed by a session whose requests go through the stub URLProtocol.
+    /// `protocolClasses` on the configuration also applies to an injected session,
+    /// unlike globally registered classes, which only ever affect `URLSession.shared`.
     private func makeStubbedAPI() -> API {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [ArticleRecoveryURLProtocol.self]

--- a/readeckTests/API/HTTPSessionMock.swift
+++ b/readeckTests/API/HTTPSessionMock.swift
@@ -8,16 +8,15 @@
 import Foundation
 @testable import readeck
 
-/// Einfacher HTTPSession-Mock: liefert vorgegebene Antworten nacheinander und
-/// zeichnet die gesendeten Requests auf. Reicht die Stub-Liste nicht aus, wird
-/// der letzte Stub wiederholt.
+/// Simple HTTPSession mock: returns the given responses in order and records the
+/// requests it was handed. Once the stub list runs out, the last stub repeats.
 final class MockHTTPSession: HTTPSession {
     enum Stub {
-        /// Erfolgreiche HTTP-Antwort mit Statuscode, Body und optionalen Headern.
+        /// Successful HTTP response with status code, body and optional headers.
         case http(status: Int, data: Data, headers: [String: String] = [:])
-        /// Beliebige (Data, URLResponse) - z. B. eine Nicht-HTTP-Antwort zum Testen von invalidResponse.
+        /// Any (Data, URLResponse) pair, e.g. a non-HTTP response to exercise invalidResponse.
         case raw(Data, URLResponse)
-        /// Wirft einen Fehler, etwa einen URLError für Server-nicht-erreichbar.
+        /// Throws an error, e.g. a URLError standing in for an unreachable server.
         case failure(Error)
     }
 
@@ -61,7 +60,7 @@ final class MockHTTPSession: HTTPSession {
 }
 
 extension MockHTTPSession.Stub {
-    /// Bequemer Erfolg mit JSON-String-Body.
+    /// Convenience success with a JSON string body.
     static func json(_ json: String, status: Int = 200) -> MockHTTPSession.Stub {
         .http(status: status, data: Data(json.utf8))
     }

--- a/readeckTests/Helpers/RepositoryTestSupport.swift
+++ b/readeckTests/Helpers/RepositoryTestSupport.swift
@@ -11,9 +11,9 @@ import CoreData
 
 // MARK: - Stub API
 
-/// PAPI-Stub mit Closure-Handlern statt `fatalError`-Platzhaltern.
-/// Nicht gesetzte Handler werfen `notStubbed`, damit ein Test sofort zeigt,
-/// welchen Aufruf er nicht erwartet hat.
+/// PAPI stub with closure handlers instead of `fatalError` placeholders.
+/// Unset handlers throw `notStubbed`, so a test immediately shows which call
+/// it did not expect.
 final class StubAPI: PAPI, @unchecked Sendable {
     enum StubError: Error, Equatable {
         case notStubbed(String)
@@ -32,7 +32,7 @@ final class StubAPI: PAPI, @unchecked Sendable {
     var getBookmarkLabelsHandler: (() async throws -> [BookmarkLabelDto])?
     var loginHandler: ((String, String, String) async throws -> UserDto)?
 
-    // Aufzeichnungen für Assertions
+    // Recorded calls for assertions
     private(set) var updateBookmarkCalls: [(String, UpdateBookmarkRequestDto)] = []
     private(set) var deleteBookmarkCalls: [String] = []
     private(set) var createBookmarkCalls: [CreateBookmarkRequestDto] = []
@@ -107,7 +107,7 @@ final class StubAPI: PAPI, @unchecked Sendable {
 
 // MARK: - Recording Token Provider
 
-/// TokenProvider, der Schreibzugriffe im Speicher hält und mitschreibt.
+/// TokenProvider that keeps writes in memory and records them.
 final class RecordingTokenProvider: TokenProvider, @unchecked Sendable {
     private(set) var token: String?
     private(set) var endpoint: String?
@@ -141,8 +141,8 @@ final class RecordingTokenProvider: TokenProvider, @unchecked Sendable {
 
 // MARK: - Recording Settings Repository
 
-/// PSettingsRepository-Double, das gespeicherte Settings festhält.
-/// `MockSettingsRepository` aus dem App-Target hat feste Rückgaben und zeichnet nichts auf.
+/// PSettingsRepository double that records what was saved.
+/// `MockSettingsRepository` from the app target has fixed return values and records nothing.
 final class RecordingSettingsRepository: PSettingsRepository, @unchecked Sendable {
     var storedSettings: Settings?
     var loadSettingsError: Error?
@@ -219,7 +219,7 @@ extension OAuthToken {
 // MARK: - In-Memory CoreDataManager
 
 extension CoreDataManager {
-    /// CoreDataManager auf einem In-Memory-Store, für Repositories die den Manager injiziert bekommen.
+    /// CoreDataManager backed by an in-memory store, for repositories that take the manager injected.
     static func inMemory() -> CoreDataManager {
         let container = NSPersistentContainer(name: "readeck", managedObjectModel: TestCoreDataModel.shared)
         let description = NSPersistentStoreDescription()
@@ -239,8 +239,8 @@ extension CoreDataManager {
 
 // MARK: - Isolated UserDefaults
 
-/// UserDefaults in einer eigenen Suite, damit Tests sich nicht gegenseitig
-/// und nicht die echten App-Einstellungen beeinflussen.
+/// UserDefaults in a dedicated suite, so tests neither affect each other
+/// nor the real app settings.
 func makeIsolatedUserDefaults(suiteName: String = UUID().uuidString) -> UserDefaults {
     guard let defaults = UserDefaults(suiteName: suiteName) else {
         preconditionFailure("Could not create UserDefaults suite \(suiteName)")

--- a/readeckTests/Helpers/RepositoryTestSupport.swift
+++ b/readeckTests/Helpers/RepositoryTestSupport.swift
@@ -1,0 +1,314 @@
+//
+//  RepositoryTestSupport.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Foundation
+import CoreData
+@testable import readeck
+
+// MARK: - Stub API
+
+/// PAPI-Stub mit Closure-Handlern statt `fatalError`-Platzhaltern.
+/// Nicht gesetzte Handler werfen `notStubbed`, damit ein Test sofort zeigt,
+/// welchen Aufruf er nicht erwartet hat.
+final class StubAPI: PAPI, @unchecked Sendable {
+    enum StubError: Error, Equatable {
+        case notStubbed(String)
+    }
+
+    var tokenProvider: TokenProvider = TestMockTokenProvider()
+
+    // swiftlint:disable:next discouraged_optional_collection
+    var getBookmarksHandler: ((BookmarkState?, Int?, Int?, String?, [BookmarkType]?, String?, String?) async throws -> BookmarksPageDto)?
+    var getBookmarkHandler: ((String) async throws -> BookmarkDetailDto)?
+    var getBookmarkArticleHandler: ((String) async throws -> String)?
+    var createBookmarkHandler: ((CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto)?
+    var updateBookmarkHandler: ((String, UpdateBookmarkRequestDto) async throws -> Void)?
+    var deleteBookmarkHandler: ((String) async throws -> Void)?
+    var searchBookmarksHandler: ((String) async throws -> BookmarksPageDto)?
+    var getBookmarkLabelsHandler: (() async throws -> [BookmarkLabelDto])?
+    var loginHandler: ((String, String, String) async throws -> UserDto)?
+
+    // Aufzeichnungen für Assertions
+    private(set) var updateBookmarkCalls: [(String, UpdateBookmarkRequestDto)] = []
+    private(set) var deleteBookmarkCalls: [String] = []
+    private(set) var createBookmarkCalls: [CreateBookmarkRequestDto] = []
+
+    func login(endpoint: String, username: String, password: String) async throws -> UserDto {
+        guard let loginHandler else { throw StubError.notStubbed("login") }
+        return try await loginHandler(endpoint, username, password)
+    }
+
+    // swiftlint:disable:next discouraged_optional_collection
+    func getBookmarks(state: BookmarkState?, limit: Int?, offset: Int?, search: String?, type: [BookmarkType]?, tag: String?, sort: String?) async throws -> BookmarksPageDto {
+        guard let getBookmarksHandler else { throw StubError.notStubbed("getBookmarks") }
+        return try await getBookmarksHandler(state, limit, offset, search, type, tag, sort)
+    }
+
+    func getBookmark(id: String) async throws -> BookmarkDetailDto {
+        guard let getBookmarkHandler else { throw StubError.notStubbed("getBookmark") }
+        return try await getBookmarkHandler(id)
+    }
+
+    func getBookmarkArticle(id: String) async throws -> String {
+        guard let getBookmarkArticleHandler else { throw StubError.notStubbed("getBookmarkArticle") }
+        return try await getBookmarkArticleHandler(id)
+    }
+
+    func createBookmark(createRequest: CreateBookmarkRequestDto) async throws -> CreateBookmarkResponseDto {
+        createBookmarkCalls.append(createRequest)
+        guard let createBookmarkHandler else { throw StubError.notStubbed("createBookmark") }
+        return try await createBookmarkHandler(createRequest)
+    }
+
+    func updateBookmark(id: String, updateRequest: UpdateBookmarkRequestDto) async throws {
+        updateBookmarkCalls.append((id, updateRequest))
+        guard let updateBookmarkHandler else { throw StubError.notStubbed("updateBookmark") }
+        try await updateBookmarkHandler(id, updateRequest)
+    }
+
+    func deleteBookmark(id: String) async throws {
+        deleteBookmarkCalls.append(id)
+        guard let deleteBookmarkHandler else { throw StubError.notStubbed("deleteBookmark") }
+        try await deleteBookmarkHandler(id)
+    }
+
+    func searchBookmarks(search: String) async throws -> BookmarksPageDto {
+        guard let searchBookmarksHandler else { throw StubError.notStubbed("searchBookmarks") }
+        return try await searchBookmarksHandler(search)
+    }
+
+    func getBookmarkLabels() async throws -> [BookmarkLabelDto] {
+        guard let getBookmarkLabelsHandler else { throw StubError.notStubbed("getBookmarkLabels") }
+        return try await getBookmarkLabelsHandler()
+    }
+
+    func getBookmarkAnnotations(bookmarkId: String) async throws -> [AnnotationDto] { [] }
+
+    func createAnnotation(bookmarkId: String, color: String, startOffset: Int, endOffset: Int, startSelector: String, endSelector: String) async throws -> AnnotationDto {
+        throw StubError.notStubbed("createAnnotation")
+    }
+
+    func deleteAnnotation(bookmarkId: String, annotationId: String) async throws {
+        throw StubError.notStubbed("deleteAnnotation")
+    }
+
+    func registerOAuthClient(endpoint: String, request: OAuthClientCreateDto) async throws -> OAuthClientResponseDto {
+        throw StubError.notStubbed("registerOAuthClient")
+    }
+
+    func exchangeOAuthToken(endpoint: String, request: OAuthTokenRequestDto) async throws -> OAuthTokenResponseDto {
+        throw StubError.notStubbed("exchangeOAuthToken")
+    }
+}
+
+// MARK: - Recording Token Provider
+
+/// TokenProvider, der Schreibzugriffe im Speicher hält und mitschreibt.
+final class RecordingTokenProvider: TokenProvider, @unchecked Sendable {
+    private(set) var token: String?
+    private(set) var endpoint: String?
+    private(set) var oauthToken: OAuthToken?
+    private(set) var authMethod: AuthenticationMethod?
+    private(set) var oauthClientId: String?
+    private(set) var clearTokenCallCount = 0
+
+    init(token: String? = "existing-token", endpoint: String? = "https://mock.example.com") {
+        self.token = token
+        self.endpoint = endpoint
+    }
+
+    func getToken() async -> String? { token }
+    func setToken(_ token: String) async { self.token = token }
+    func clearToken() async {
+        clearTokenCallCount += 1
+        token = nil
+    }
+    func getEndpoint() async -> String? { endpoint }
+    func setEndpoint(_ endpoint: String) async { self.endpoint = endpoint }
+    func clearEndpoint() async { endpoint = nil }
+
+    func getOAuthToken() async -> OAuthToken? { oauthToken }
+    func setOAuthToken(_ token: OAuthToken) async { oauthToken = token }
+    func getAuthMethod() async -> AuthenticationMethod? { authMethod }
+    func setAuthMethod(_ method: AuthenticationMethod) async { authMethod = method }
+    func setOAuthClientId(_ clientId: String) async { oauthClientId = clientId }
+    func getOAuthClientId() async -> String? { oauthClientId }
+}
+
+// MARK: - Recording Settings Repository
+
+/// PSettingsRepository-Double, das gespeicherte Settings festhält.
+/// `MockSettingsRepository` aus dem App-Target hat feste Rückgaben und zeichnet nichts auf.
+final class RecordingSettingsRepository: PSettingsRepository, @unchecked Sendable {
+    var storedSettings: Settings?
+    var loadSettingsError: Error?
+    private(set) var savedSettings: [Settings] = []
+
+    var hasFinishedSetup = true
+
+    init(storedSettings: Settings? = Settings()) {
+        self.storedSettings = storedSettings
+    }
+
+    func saveSettings(_ settings: Settings) async throws {
+        savedSettings.append(settings)
+        storedSettings = settings
+    }
+
+    func loadSettings() async throws -> Settings? {
+        if let loadSettingsError { throw loadSettingsError }
+        return storedSettings
+    }
+
+    func clearSettings() async throws { storedSettings = nil }
+    func saveToken(_ token: String) async throws {}
+    func saveUsername(_ username: String) async throws {}
+    func savePassword(_ password: String) async throws {}
+    func saveHasFinishedSetup(_ hasFinishedSetup: Bool) async throws { self.hasFinishedSetup = hasFinishedSetup }
+    func saveServerSettings(endpoint: String, username: String, password: String, token: String) async throws {}
+    func saveCardLayoutStyle(_ cardLayoutStyle: CardLayoutStyle) async throws {}
+    func loadCardLayoutStyle() async throws -> CardLayoutStyle { .magazine }
+    func saveTagSortOrder(_ tagSortOrder: TagSortOrder) async throws {}
+    func loadTagSortOrder() async throws -> TagSortOrder { .byCount }
+    func loadOfflineSettings() async throws -> OfflineSettings { OfflineSettings() }
+    func saveOfflineSettings(_ settings: OfflineSettings) async throws {}
+    func getCacheSize() async throws -> UInt { 0 }
+    func getMaxCacheSize() async throws -> UInt { 200 * 1024 * 1024 }
+    func updateMaxCacheSize(_ sizeInBytes: UInt) async throws {}
+    func clearCache() async throws {}
+    func applyCacheSizeLimit() async throws {}
+}
+
+// MARK: - Stub GetUserProfileUseCase
+
+final class StubGetUserProfileUseCase: PGetUserProfileUseCase, @unchecked Sendable {
+    var result: Result<String, Error>
+
+    init(username: String = "ilyas") {
+        self.result = .success(username)
+    }
+
+    func execute() async throws -> String {
+        try result.get()
+    }
+}
+
+// MARK: - OAuth Fixtures
+
+extension OAuthToken {
+    static func fixture(
+        accessToken: String = "access-123",
+        refreshToken: String? = "refresh-123",
+        expiresIn: Int? = 3600
+    ) -> OAuthToken {
+        OAuthToken(
+            accessToken: accessToken,
+            tokenType: "Bearer",
+            scope: nil,
+            expiresIn: expiresIn,
+            refreshToken: refreshToken,
+            createdAt: Date(timeIntervalSince1970: 1_767_225_600)
+        )
+    }
+}
+
+// MARK: - In-Memory CoreDataManager
+
+extension CoreDataManager {
+    /// CoreDataManager auf einem In-Memory-Store, für Repositories die den Manager injiziert bekommen.
+    static func inMemory() -> CoreDataManager {
+        let container = NSPersistentContainer(name: "readeck", managedObjectModel: TestCoreDataModel.shared)
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+
+        container.loadPersistentStores { _, error in
+            precondition(error == nil, "In-memory store failed to load: \(String(describing: error))")
+        }
+
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        return CoreDataManager(container: container)
+    }
+}
+
+// MARK: - Isolated UserDefaults
+
+/// UserDefaults in einer eigenen Suite, damit Tests sich nicht gegenseitig
+/// und nicht die echten App-Einstellungen beeinflussen.
+func makeIsolatedUserDefaults(suiteName: String = UUID().uuidString) -> UserDefaults {
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+        preconditionFailure("Could not create UserDefaults suite \(suiteName)")
+    }
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+}
+
+// MARK: - DTO Fixtures
+
+enum DtoFixture {
+    static func bookmark(
+        id: String = "bm1",
+        title: String = "Test Bookmark",
+        labels: [String] = [],
+        isArchived: Bool = false,
+        isMarked: Bool = false,
+        readProgress: Int = 0
+    ) -> BookmarkDto {
+        BookmarkDto(
+            id: id,
+            title: title,
+            url: "https://example.com/\(id)",
+            href: "https://api.example.com/bookmarks/\(id)",
+            description: "A description",
+            authors: ["Author"],
+            created: "2026-01-01T00:00:00Z",
+            published: nil,
+            updated: "2026-01-02T00:00:00Z",
+            siteName: "Example",
+            site: "example.com",
+            readingTime: 5,
+            wordCount: 1000,
+            hasArticle: true,
+            isArchived: isArchived,
+            isDeleted: false,
+            isMarked: isMarked,
+            labels: labels,
+            lang: "en",
+            loaded: true,
+            readProgress: readProgress,
+            documentType: "article",
+            state: 0,
+            textDirection: "ltr",
+            type: "article",
+            resources: BookmarkResourcesDto(
+                article: ResourceDto(src: "https://example.com/\(id)/article"),
+                icon: nil,
+                image: ImageResourceDto(src: "https://example.com/\(id)/image.jpg", height: 600, width: 800),
+                log: nil,
+                props: nil,
+                thumbnail: ImageResourceDto(src: "https://example.com/\(id)/thumb.jpg", height: 150, width: 200)
+            )
+        )
+    }
+
+    static func page(
+        bookmarks: [BookmarkDto],
+        currentPage: Int? = 1,
+        totalCount: Int? = nil,
+        totalPages: Int? = 1
+    ) -> BookmarksPageDto {
+        BookmarksPageDto(
+            bookmarks: bookmarks,
+            currentPage: currentPage,
+            totalCount: totalCount ?? bookmarks.count,
+            totalPages: totalPages,
+            links: nil
+        )
+    }
+}

--- a/readeckTests/Helpers/TestMocks.swift
+++ b/readeckTests/Helpers/TestMocks.swift
@@ -117,12 +117,12 @@ class TestMockTokenProvider: TokenProvider {
 
 // MARK: - Shared Test CoreData Model
 
-/// Ein einziges Modell für alle In-Memory-Stores der Tests.
+/// A single model shared by every in-memory store in the tests.
 ///
-/// `NSManagedObjectModel.mergedModel(from:)` pro Instanz aufzurufen erzeugt mehrere
-/// Modelle, die dieselbe NSManagedObject-Subklasse beanspruchen. CoreData kann `+entity`
-/// dann nicht mehr auflösen ("Failed to find a unique match for an NSEntityDescription")
-/// und stürzt beim Speichern ab, sobald mehrere CoreData-Suiten im selben Prozess laufen.
+/// Calling `NSManagedObjectModel.mergedModel(from:)` per instance creates several models
+/// that all claim the same NSManagedObject subclass. CoreData can then no longer resolve
+/// `+entity` ("Failed to find a unique match for an NSEntityDescription") and crashes on
+/// save as soon as multiple CoreData suites run in the same process.
 enum TestCoreDataModel {
     static let shared: NSManagedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
 }

--- a/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
+++ b/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
@@ -7,7 +7,7 @@ private enum Config {
     static let token = "PASTE_TOKEN_HERE"
     static let endpoint = "PASTE_ENDPOINT_HERE"
 
-    /// Ohne echte Zugangsdaten wird der Test übersprungen statt fehlzuschlagen.
+    /// Without real credentials the test is skipped instead of failing.
     static var isConfigured: Bool {
         !token.hasPrefix("PASTE_") && !endpoint.hasPrefix("PASTE_")
     }

--- a/readeckTests/Repository/AuthRepositoryTests.swift
+++ b/readeckTests/Repository/AuthRepositoryTests.swift
@@ -1,0 +1,190 @@
+//
+//  AuthRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("AuthRepository Tests")
+struct AuthRepositoryTests {
+
+    private func makeRepository(
+        tokenProvider: RecordingTokenProvider = RecordingTokenProvider(),
+        settings: RecordingSettingsRepository = RecordingSettingsRepository(),
+        profile: StubGetUserProfileUseCase = StubGetUserProfileUseCase()
+    ) -> (AuthRepository, StubAPI, RecordingTokenProvider, RecordingSettingsRepository) {
+        let api = StubAPI()
+        api.tokenProvider = tokenProvider
+        let repository = AuthRepository(
+            api: api,
+            settingsRepository: settings,
+            getUserProfileUseCase: profile
+        )
+        return (repository, api, tokenProvider, settings)
+    }
+
+    // MARK: - Classic Login
+
+    @Test("login returns the user and switches the auth method to apiToken")
+    func loginSucceeds() async throws {
+        let (repository, api, tokenProvider, _) = makeRepository()
+        api.loginHandler = { _, _, _ in UserDto(id: "u1", token: "tok-1") }
+
+        let user = try await repository.login(
+            endpoint: "https://readeck.example.com", username: "ilyas", password: "pw"
+        )
+
+        #expect(user.id == "u1")
+        #expect(user.token == "tok-1")
+        #expect(tokenProvider.authMethod == .apiToken)
+    }
+
+    @Test("login passes the credentials through to the API")
+    func loginForwardsCredentials() async throws {
+        let (repository, api, _, _) = makeRepository()
+        var received: (endpoint: String, username: String, password: String)?
+        api.loginHandler = { endpoint, username, password in
+            received = (endpoint, username, password)
+            return UserDto(id: "u1", token: "tok-1")
+        }
+
+        _ = try await repository.login(
+            endpoint: "https://readeck.example.com", username: "ilyas", password: "secret"
+        )
+
+        #expect(received?.endpoint == "https://readeck.example.com")
+        #expect(received?.username == "ilyas")
+        #expect(received?.password == "secret")
+    }
+
+    @Test("login propagates an API error and leaves the auth method untouched")
+    func loginPropagatesError() async throws {
+        let (repository, api, tokenProvider, _) = makeRepository()
+        api.loginHandler = { _, _, _ in throw APIError.serverError(401) }
+
+        await #expect(throws: APIError.serverError(401)) {
+            _ = try await repository.login(endpoint: "https://x", username: "a", password: "b")
+        }
+        #expect(tokenProvider.authMethod == nil)
+    }
+
+    // MARK: - Logout
+
+    @Test("logout clears the token and resets the auth method")
+    func logoutClearsToken() async throws {
+        let (repository, _, tokenProvider, _) = makeRepository()
+
+        try await repository.logout()
+
+        #expect(tokenProvider.clearTokenCallCount == 1)
+        #expect(tokenProvider.token == nil)
+        #expect(tokenProvider.authMethod == .apiToken)
+    }
+
+    // MARK: - OAuth Login
+
+    @Test("loginWithOAuth persists token, method, client id and endpoint")
+    func oauthPersistsCredentials() async throws {
+        let (repository, _, tokenProvider, _) = makeRepository()
+        let token = OAuthToken.fixture()
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: token, clientId: "client-1"
+        )
+
+        #expect(tokenProvider.oauthToken?.accessToken == "access-123")
+        #expect(tokenProvider.authMethod == .oauth)
+        #expect(tokenProvider.oauthClientId == "client-1")
+        #expect(tokenProvider.endpoint == "https://readeck.example.com")
+    }
+
+    @Test("loginWithOAuth writes endpoint and username into the settings")
+    func oauthUpdatesSettings() async throws {
+        let settings = RecordingSettingsRepository(storedSettings: Settings())
+        let (repository, _, _, _) = makeRepository(
+            settings: settings, profile: StubGetUserProfileUseCase(username: "ilyas")
+        )
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: .fixture(), clientId: "client-1"
+        )
+
+        #expect(settings.savedSettings.count == 1)
+        #expect(settings.savedSettings.first?.endpoint == "https://readeck.example.com")
+        #expect(settings.savedSettings.first?.username == "ilyas")
+    }
+
+    @Test("loginWithOAuth skips the settings write when none are stored yet")
+    func oauthWithoutExistingSettings() async throws {
+        let settings = RecordingSettingsRepository(storedSettings: nil)
+        let (repository, _, tokenProvider, _) = makeRepository(settings: settings)
+
+        try await repository.loginWithOAuth(
+            endpoint: "https://readeck.example.com", token: .fixture(), clientId: "client-1"
+        )
+
+        // Der Token-Teil muss trotzdem persistiert sein.
+        #expect(tokenProvider.authMethod == .oauth)
+        #expect(settings.savedSettings.isEmpty)
+    }
+
+    @Test("loginWithOAuth propagates a failing profile fetch")
+    func oauthPropagatesProfileError() async throws {
+        let profile = StubGetUserProfileUseCase()
+        profile.result = .failure(APIError.serverError(403))
+        let (repository, _, _, settings) = makeRepository(profile: profile)
+
+        await #expect(throws: APIError.serverError(403)) {
+            try await repository.loginWithOAuth(
+                endpoint: "https://x", token: .fixture(), clientId: "c"
+            )
+        }
+        #expect(settings.savedSettings.isEmpty)
+    }
+
+    // MARK: - Auth Method / Switching
+
+    @Test("getAuthenticationMethod reads through to the token provider")
+    func getAuthenticationMethod() async throws {
+        let tokenProvider = RecordingTokenProvider()
+        await tokenProvider.setAuthMethod(.oauth)
+        let (repository, _, _, _) = makeRepository(tokenProvider: tokenProvider)
+
+        #expect(await repository.getAuthenticationMethod() == .oauth)
+    }
+
+    @Test("switchToClassicAuth clears the old token before logging in again")
+    func switchToClassicAuth() async throws {
+        let tokenProvider = RecordingTokenProvider()
+        await tokenProvider.setAuthMethod(.oauth)
+        let (repository, api, provider, _) = makeRepository(tokenProvider: tokenProvider)
+        api.loginHandler = { _, _, _ in UserDto(id: "u2", token: "tok-2") }
+
+        let user = try await repository.switchToClassicAuth(
+            endpoint: "https://x", username: "a", password: "b"
+        )
+
+        #expect(user.id == "u2")
+        #expect(provider.clearTokenCallCount == 1)
+        #expect(provider.authMethod == .apiToken)
+    }
+
+    // MARK: - getCurrentSettings
+
+    @Test("getCurrentSettings reads through to the settings repository")
+    func getCurrentSettings() async throws {
+        var stored = Settings()
+        stored.endpoint = "https://stored.example.com"
+        let (repository, _, _, _) = makeRepository(
+            settings: RecordingSettingsRepository(storedSettings: stored)
+        )
+
+        let settings = try await repository.getCurrentSettings()
+
+        #expect(settings?.endpoint == "https://stored.example.com")
+    }
+}

--- a/readeckTests/Repository/AuthRepositoryTests.swift
+++ b/readeckTests/Repository/AuthRepositoryTests.swift
@@ -127,7 +127,7 @@ struct AuthRepositoryTests {
             endpoint: "https://readeck.example.com", token: .fixture(), clientId: "client-1"
         )
 
-        // Der Token-Teil muss trotzdem persistiert sein.
+        // The token side of the flow must still be persisted.
         #expect(tokenProvider.authMethod == .oauth)
         #expect(settings.savedSettings.isEmpty)
     }

--- a/readeckTests/Repository/BookmarksRepositoryTests.swift
+++ b/readeckTests/Repository/BookmarksRepositoryTests.swift
@@ -1,0 +1,182 @@
+//
+//  BookmarksRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("BookmarksRepository Tests")
+struct BookmarksRepositoryTests {
+
+    // MARK: - fetchBookmarks / DTO → Domain
+
+    @Test("fetchBookmarks maps the page and all bookmark fields to the domain model")
+    func fetchBookmarksMapsToDomain() async throws {
+        let api = StubAPI()
+        api.getBookmarksHandler = { _, _, _, _, _, _, _ in
+            DtoFixture.page(
+                bookmarks: [DtoFixture.bookmark(id: "a", title: "First", labels: ["swift"], isMarked: true)],
+                currentPage: 2,
+                totalCount: 42,
+                totalPages: 5
+            )
+        }
+        let repository = BookmarksRepository(api: api)
+
+        let page = try await repository.fetchBookmarks()
+
+        #expect(page.currentPage == 2)
+        #expect(page.totalCount == 42)
+        #expect(page.totalPages == 5)
+        #expect(page.bookmarks.count == 1)
+
+        let bookmark = try #require(page.bookmarks.first)
+        #expect(bookmark.id == "a")
+        #expect(bookmark.title == "First")
+        #expect(bookmark.url == "https://example.com/a")
+        #expect(bookmark.labels == ["swift"])
+        #expect(bookmark.isMarked == true)
+        #expect(bookmark.isArchived == false)
+        #expect(bookmark.readingTime == 5)
+        #expect(bookmark.wordCount == 1000)
+        // Verschachteltes Resource-Mapping
+        #expect(bookmark.resources.article?.src == "https://example.com/a/article")
+        #expect(bookmark.resources.thumbnail?.src == "https://example.com/a/thumb.jpg")
+        #expect(bookmark.resources.image?.width == 800)
+        #expect(bookmark.resources.icon == nil)
+    }
+
+    @Test("fetchBookmarks forwards its filter arguments to the API unchanged")
+    func fetchBookmarksForwardsArguments() async throws {
+        let api = StubAPI()
+        var received: (state: BookmarkState?, limit: Int?, offset: Int?, search: String?, tag: String?, sort: String?)?
+        api.getBookmarksHandler = { state, limit, offset, search, _, tag, sort in
+            received = (state, limit, offset, search, tag, sort)
+            return DtoFixture.page(bookmarks: [])
+        }
+        let repository = BookmarksRepository(api: api)
+
+        _ = try await repository.fetchBookmarks(
+            state: .unread, limit: 10, offset: 20, search: "swift", type: nil, tag: "ios", sort: "-created"
+        )
+
+        #expect(received?.state == .unread)
+        #expect(received?.limit == 10)
+        #expect(received?.offset == 20)
+        #expect(received?.search == "swift")
+        #expect(received?.tag == "ios")
+        #expect(received?.sort == "-created")
+    }
+
+    @Test("fetchBookmarks propagates API errors")
+    func fetchBookmarksPropagatesError() async throws {
+        let api = StubAPI()
+        api.getBookmarksHandler = { _, _, _, _, _, _, _ in throw APIError.serverError(500) }
+        let repository = BookmarksRepository(api: api)
+
+        await #expect(throws: APIError.serverError(500)) {
+            _ = try await repository.fetchBookmarks()
+        }
+    }
+
+    // MARK: - fetchBookmark
+
+    @Test("fetchBookmark maps the detail, flattening resource URLs")
+    func fetchBookmarkMapsDetail() async throws {
+        let api = StubAPI()
+        api.getBookmarkHandler = { id in DtoFixture.bookmark(id: id, title: "Detail", labels: ["a", "b"]) }
+        let repository = BookmarksRepository(api: api)
+
+        let detail = try await repository.fetchBookmark(id: "bm42")
+
+        #expect(detail.id == "bm42")
+        #expect(detail.title == "Detail")
+        #expect(detail.labels == ["a", "b"])
+        #expect(detail.thumbnailUrl == "https://example.com/bm42/thumb.jpg")
+        #expect(detail.imageUrl == "https://example.com/bm42/image.jpg")
+        #expect(detail.lang == "en")
+        #expect(detail.hasArticle == true)
+    }
+
+    // MARK: - createBookmark
+
+    @Test("createBookmark returns the message on an accepted status", arguments: [0, 202])
+    func createBookmarkSuccess(status: Int) async throws {
+        let api = StubAPI()
+        api.createBookmarkHandler = { _ in CreateBookmarkResponseDto(message: "new-id", status: status) }
+        let repository = BookmarksRepository(api: api)
+
+        let id = try await repository.createBookmark(
+            createRequest: CreateBookmarkRequest(url: "https://example.com", title: "T", labels: ["x"])
+        )
+
+        #expect(id == "new-id")
+        #expect(api.createBookmarkCalls.count == 1)
+        #expect(api.createBookmarkCalls[0].url == "https://example.com")
+        #expect(api.createBookmarkCalls[0].labels == ["x"])
+    }
+
+    @Test("createBookmark throws a serverError on an unexpected status")
+    func createBookmarkRejectsUnexpectedStatus() async throws {
+        let api = StubAPI()
+        api.createBookmarkHandler = { _ in CreateBookmarkResponseDto(message: "nope", status: 500) }
+        let repository = BookmarksRepository(api: api)
+
+        await #expect(throws: CreateBookmarkError.self) {
+            _ = try await repository.createBookmark(
+                createRequest: CreateBookmarkRequest(url: "https://example.com", title: nil, labels: nil)
+            )
+        }
+    }
+
+    // MARK: - update / delete
+
+    @Test("updateBookmark passes the id and maps the request to its DTO")
+    func updateBookmarkMapsRequest() async throws {
+        let api = StubAPI()
+        api.updateBookmarkHandler = { _, _ in }
+        let repository = BookmarksRepository(api: api)
+
+        try await repository.updateBookmark(
+            id: "bm1",
+            updateRequest: BookmarkUpdateRequest(isArchived: true, isMarked: false, readProgress: 80)
+        )
+
+        #expect(api.updateBookmarkCalls.count == 1)
+        #expect(api.updateBookmarkCalls[0].0 == "bm1")
+        #expect(api.updateBookmarkCalls[0].1.isArchived == true)
+        #expect(api.updateBookmarkCalls[0].1.isMarked == false)
+        #expect(api.updateBookmarkCalls[0].1.readProgress == 80)
+    }
+
+    @Test("deleteBookmark forwards the id")
+    func deleteBookmarkForwardsId() async throws {
+        let api = StubAPI()
+        api.deleteBookmarkHandler = { _ in }
+        let repository = BookmarksRepository(api: api)
+
+        try await repository.deleteBookmark(id: "bm9")
+
+        #expect(api.deleteBookmarkCalls == ["bm9"])
+    }
+
+    // MARK: - searchBookmarks
+
+    @Test("searchBookmarks maps results to the domain model")
+    func searchBookmarksMapsResults() async throws {
+        let api = StubAPI()
+        api.searchBookmarksHandler = { term in
+            DtoFixture.page(bookmarks: [DtoFixture.bookmark(id: "s1", title: "Found \(term)")])
+        }
+        let repository = BookmarksRepository(api: api)
+
+        let page = try await repository.searchBookmarks(search: "swift")
+
+        #expect(page.bookmarks.count == 1)
+        #expect(page.bookmarks.first?.title == "Found swift")
+    }
+}

--- a/readeckTests/Repository/LabelsRepositoryTests.swift
+++ b/readeckTests/Repository/LabelsRepositoryTests.swift
@@ -19,9 +19,12 @@ struct LabelsRepositoryTests {
         return (LabelsRepository(api: api, coreDataManager: coreData), api, coreData)
     }
 
-    private func fetchTags(_ coreData: CoreDataManager) throws -> [TagEntity] {
+    /// Bewusst die async-Variante von `perform`: `performAndWait` würde den
+    /// aufrufenden Thread blockieren, in einem async-Test also einen Thread des
+    /// Swift-Concurrency-Pools.
+    private func fetchTags(_ coreData: CoreDataManager) async throws -> [TagEntity] {
         let context = coreData.context
-        return try context.performAndWait {
+        return try await context.perform {
             let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
             request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
             return try context.fetch(request)
@@ -39,7 +42,7 @@ struct LabelsRepositoryTests {
             BookmarkLabelDto(name: "ios", count: 1, href: "/ios")
         ])
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 2)
         #expect(tags.map(\.name) == ["ios", "swift"])
         #expect(tags.first { $0.name == "swift" }?.count == 3)
@@ -52,7 +55,7 @@ struct LabelsRepositoryTests {
         try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 3, href: "/swift")])
         try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 7, href: "/swift")])
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 1)
         #expect(tags.first?.count == 7)
     }
@@ -65,7 +68,7 @@ struct LabelsRepositoryTests {
 
         try await repository.saveNewLabel(name: "kotlin")
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 1)
         #expect(tags.first?.name == "kotlin")
         #expect(tags.first?.count == 1)
@@ -78,7 +81,7 @@ struct LabelsRepositoryTests {
         try await repository.saveNewLabel(name: "  spaced  ")
         try await repository.saveNewLabel(name: "   ")
 
-        let tags = try fetchTags(coreData)
+        let tags = try await fetchTags(coreData)
         #expect(tags.count == 1)
         #expect(tags.first?.name == "spaced")
     }
@@ -90,7 +93,7 @@ struct LabelsRepositoryTests {
         try await repository.saveNewLabel(name: "swift")
         try await repository.saveNewLabel(name: "swift")
 
-        #expect(try fetchTags(coreData).count == 1)
+        #expect(try await fetchTags(coreData).count == 1)
     }
 
     // MARK: - getLabels

--- a/readeckTests/Repository/LabelsRepositoryTests.swift
+++ b/readeckTests/Repository/LabelsRepositoryTests.swift
@@ -19,9 +19,8 @@ struct LabelsRepositoryTests {
         return (LabelsRepository(api: api, coreDataManager: coreData), api, coreData)
     }
 
-    /// Bewusst die async-Variante von `perform`: `performAndWait` würde den
-    /// aufrufenden Thread blockieren, in einem async-Test also einen Thread des
-    /// Swift-Concurrency-Pools.
+    /// Deliberately the async variant of `perform`: `performAndWait` would block the
+    /// calling thread, which inside an async test is a thread of the Swift concurrency pool.
     private func fetchTags(_ coreData: CoreDataManager) async throws -> [TagEntity] {
         let context = coreData.context
         return try await context.perform {

--- a/readeckTests/Repository/LabelsRepositoryTests.swift
+++ b/readeckTests/Repository/LabelsRepositoryTests.swift
@@ -98,7 +98,7 @@ struct LabelsRepositoryTests {
     @Test("getLabels returns the cached labels sorted by count, then name")
     func getLabelsReturnsCacheSorted() async throws {
         let (repository, api, _) = makeRepository()
-        // Der Hintergrund-Refresh darf den Test nicht beeinflussen.
+        // The background refresh must not interfere with the test.
         api.getBookmarkLabelsHandler = { [] }
 
         try await repository.saveLabels([
@@ -109,7 +109,7 @@ struct LabelsRepositoryTests {
 
         let labels = try await repository.getLabels()
 
-        // count absteigend, bei Gleichstand name aufsteigend
+        // count descending, name ascending on ties
         #expect(labels.map(\.name) == ["alpha", "common", "rare"])
         #expect(labels.first?.count == 9)
     }

--- a/readeckTests/Repository/LabelsRepositoryTests.swift
+++ b/readeckTests/Repository/LabelsRepositoryTests.swift
@@ -1,0 +1,137 @@
+//
+//  LabelsRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+import CoreData
+@testable import readeck
+
+@Suite("LabelsRepository Tests")
+struct LabelsRepositoryTests {
+
+    private func makeRepository() -> (LabelsRepository, StubAPI, CoreDataManager) {
+        let api = StubAPI()
+        let coreData = CoreDataManager.inMemory()
+        return (LabelsRepository(api: api, coreDataManager: coreData), api, coreData)
+    }
+
+    private func fetchTags(_ coreData: CoreDataManager) throws -> [TagEntity] {
+        let context = coreData.context
+        return try context.performAndWait {
+            let request: NSFetchRequest<TagEntity> = TagEntity.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
+            return try context.fetch(request)
+        }
+    }
+
+    // MARK: - saveLabels
+
+    @Test("saveLabels inserts new labels with their counts")
+    func saveLabelsInserts() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveLabels([
+            BookmarkLabelDto(name: "swift", count: 3, href: "/swift"),
+            BookmarkLabelDto(name: "ios", count: 1, href: "/ios")
+        ])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 2)
+        #expect(tags.map(\.name) == ["ios", "swift"])
+        #expect(tags.first { $0.name == "swift" }?.count == 3)
+    }
+
+    @Test("saveLabels updates the count of an existing label instead of duplicating it")
+    func saveLabelsUpdatesExisting() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 3, href: "/swift")])
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 7, href: "/swift")])
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.count == 7)
+    }
+
+    // MARK: - saveNewLabel
+
+    @Test("saveNewLabel creates a label with count 1")
+    func saveNewLabelCreates() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "kotlin")
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.name == "kotlin")
+        #expect(tags.first?.count == 1)
+    }
+
+    @Test("saveNewLabel trims whitespace and ignores blank names")
+    func saveNewLabelTrimsAndIgnoresBlank() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "  spaced  ")
+        try await repository.saveNewLabel(name: "   ")
+
+        let tags = try fetchTags(coreData)
+        #expect(tags.count == 1)
+        #expect(tags.first?.name == "spaced")
+    }
+
+    @Test("saveNewLabel does not duplicate an existing label")
+    func saveNewLabelDeduplicates() async throws {
+        let (repository, _, coreData) = makeRepository()
+
+        try await repository.saveNewLabel(name: "swift")
+        try await repository.saveNewLabel(name: "swift")
+
+        #expect(try fetchTags(coreData).count == 1)
+    }
+
+    // MARK: - getLabels
+
+    @Test("getLabels returns the cached labels sorted by count, then name")
+    func getLabelsReturnsCacheSorted() async throws {
+        let (repository, api, _) = makeRepository()
+        // Der Hintergrund-Refresh darf den Test nicht beeinflussen.
+        api.getBookmarkLabelsHandler = { [] }
+
+        try await repository.saveLabels([
+            BookmarkLabelDto(name: "rare", count: 1, href: "/rare"),
+            BookmarkLabelDto(name: "common", count: 9, href: "/common"),
+            BookmarkLabelDto(name: "alpha", count: 9, href: "/alpha")
+        ])
+
+        let labels = try await repository.getLabels()
+
+        // count absteigend, bei Gleichstand name aufsteigend
+        #expect(labels.map(\.name) == ["alpha", "common", "rare"])
+        #expect(labels.first?.count == 9)
+    }
+
+    @Test("getLabels returns an empty list when nothing is cached")
+    func getLabelsEmptyCache() async throws {
+        let (repository, api, _) = makeRepository()
+        api.getBookmarkLabelsHandler = { [] }
+
+        let labels = try await repository.getLabels()
+
+        #expect(labels.isEmpty)
+    }
+
+    @Test("getLabels still returns cached data when the background sync fails")
+    func getLabelsSurvivesFailingSync() async throws {
+        let (repository, api, _) = makeRepository()
+        api.getBookmarkLabelsHandler = { throw APIError.serverError(500) }
+
+        try await repository.saveLabels([BookmarkLabelDto(name: "swift", count: 2, href: "/swift")])
+        let labels = try await repository.getLabels()
+
+        #expect(labels.map(\.name) == ["swift"])
+    }
+}

--- a/readeckTests/Repository/SettingsRepositoryTests.swift
+++ b/readeckTests/Repository/SettingsRepositoryTests.swift
@@ -1,0 +1,204 @@
+//
+//  SettingsRepositoryTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+@testable import readeck
+
+/// Deckt die CoreData- und UserDefaults-gestützten Pfade ab.
+/// Die Keychain-Felder (endpoint/username/password/token) bleiben ausgespart:
+/// `SettingsRepository` greift dafür fest auf `KeychainHelper.shared` zu, ein Test
+/// würde den echten Keychain des Geräts anfassen.
+@Suite("SettingsRepository Tests")
+struct SettingsRepositoryTests {
+
+    private func makeRepository() -> (SettingsRepository, UserDefaults) {
+        let defaults = makeIsolatedUserDefaults()
+        let repository = SettingsRepository(
+            tokenProvider: RecordingTokenProvider(),
+            coreDataManager: .inMemory(),
+            userDefaults: defaults
+        )
+        return (repository, defaults)
+    }
+
+    // MARK: - UI Preferences Round-Trip
+
+    @Test("saveSettings persists the UI preferences and loadSettings reads them back")
+    func uiPreferencesRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        var settings = Settings()
+        settings.fontFamily = .serif
+        settings.fontSize = .large
+        settings.theme = .dark
+        settings.enableTTS = true
+        settings.cardLayoutStyle = .compact
+        settings.tagSortOrder = .alphabetically
+
+        try await repository.saveSettings(settings)
+        let loaded = try #require(try await repository.loadSettings())
+
+        #expect(loaded.fontFamily == .serif)
+        #expect(loaded.fontSize == .large)
+        #expect(loaded.theme == .dark)
+        #expect(loaded.enableTTS == true)
+        #expect(loaded.cardLayoutStyle == .compact)
+        #expect(loaded.tagSortOrder == .alphabetically)
+    }
+
+    @Test("loadSettings falls back to defaults on an empty store")
+    func loadSettingsDefaults() async throws {
+        let (repository, _) = makeRepository()
+
+        let loaded = try #require(try await repository.loadSettings())
+
+        #expect(loaded.fontFamily == .system)
+        #expect(loaded.fontSize == .medium)
+        #expect(loaded.theme == .system)
+        #expect(loaded.cardLayoutStyle == .magazine)
+        #expect(loaded.tagSortOrder == .byCount)
+    }
+
+    @Test("saveSettings updates the existing entity instead of adding a second one")
+    func saveSettingsUpdatesInPlace() async throws {
+        let (repository, _) = makeRepository()
+
+        var first = Settings()
+        first.fontSize = .small
+        try await repository.saveSettings(first)
+
+        var second = Settings()
+        second.fontSize = .large
+        try await repository.saveSettings(second)
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.fontSize == .large)
+    }
+
+    // MARK: - Reader Styling Sentinels
+
+    @Test("horizontalMargin 0 survives the round-trip, since 0 is a valid value")
+    func horizontalMarginZeroIsPreserved() async throws {
+        let (repository, _) = makeRepository()
+
+        var settings = Settings()
+        settings.horizontalMargin = 0
+        try await repository.saveSettings(settings)
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == 0)
+    }
+
+    @Test("unset fontSizeNumeric and lineHeight come back as nil rather than 0")
+    func unsetNumericValuesAreNil() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveSettings(Settings())
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.fontSizeNumeric == nil)
+        #expect(loaded.lineHeight == nil)
+    }
+
+    // Dokumentiert das Ist-Verhalten, nicht das gewünschte:
+    // loadSettings behandelt einen negativen horizontalMargin als "nicht gesetzt",
+    // der CoreData-Default des Attributs ist aber 0. Sobald irgendeine Einstellung
+    // gespeichert wurde, existiert die SettingEntity und der Margin kommt als 0
+    // zurück statt als nil - der Reader nutzt dann 0 statt der gewollten 16
+    // (siehe FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
+    @Test("known quirk: an untouched horizontalMargin reads back as 0, not nil")
+    func untouchedHorizontalMarginReadsAsZero() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveSettings(Settings())
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == 0)
+    }
+
+    // MARK: - Card Layout / Tag Sort
+
+    @Test("saveCardLayoutStyle and loadCardLayoutStyle round-trip")
+    func cardLayoutRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveCardLayoutStyle(.compact)
+
+        #expect(try await repository.loadCardLayoutStyle() == .compact)
+    }
+
+    @Test("loadCardLayoutStyle defaults to magazine")
+    func cardLayoutDefault() async throws {
+        let (repository, _) = makeRepository()
+
+        #expect(try await repository.loadCardLayoutStyle() == .magazine)
+    }
+
+    @Test("saveTagSortOrder and loadTagSortOrder round-trip")
+    func tagSortRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveTagSortOrder(.alphabetically)
+
+        #expect(try await repository.loadTagSortOrder() == .alphabetically)
+    }
+
+    // MARK: - Offline Settings
+
+    @Test("offline settings round-trip through CoreData")
+    func offlineSettingsRoundTrip() async throws {
+        let (repository, _) = makeRepository()
+        let syncDate = Date(timeIntervalSince1970: 1_767_225_600)
+
+        try await repository.saveOfflineSettings(
+            OfflineSettings(enabled: true, maxUnreadArticles: 50, saveImages: true, lastSyncDate: syncDate)
+        )
+
+        let loaded = try await repository.loadOfflineSettings()
+        #expect(loaded.enabled == true)
+        #expect(loaded.maxUnreadArticles == 50)
+        #expect(loaded.saveImages == true)
+        #expect(loaded.lastSyncDate == syncDate)
+    }
+
+    @Test("offline settings default to disabled with 20 articles")
+    func offlineSettingsDefaults() async throws {
+        let (repository, _) = makeRepository()
+
+        let loaded = try await repository.loadOfflineSettings()
+
+        #expect(loaded.enabled == false)
+        #expect(loaded.maxUnreadArticles == 20)
+        #expect(loaded.lastSyncDate == nil)
+    }
+
+    // MARK: - UserDefaults-backed
+
+    @Test("hasFinishedSetup is stored in the injected UserDefaults")
+    func hasFinishedSetupUsesInjectedDefaults() async throws {
+        let (repository, defaults) = makeRepository()
+
+        #expect(repository.hasFinishedSetup == false)
+
+        try await repository.saveHasFinishedSetup(true)
+
+        #expect(repository.hasFinishedSetup == true)
+        #expect(defaults.bool(forKey: "hasFinishedSetup") == true)
+    }
+
+    @Test("getMaxCacheSize returns and persists the 200 MB default")
+    func maxCacheSizeDefault() async throws {
+        let (repository, _) = makeRepository()
+
+        let size = try await repository.getMaxCacheSize()
+
+        #expect(size == UInt(200 * 1024 * 1024))
+        // Zweiter Aufruf liest den nun persistierten Wert.
+        #expect(try await repository.getMaxCacheSize() == size)
+    }
+}

--- a/readeckTests/Repository/SettingsRepositoryTests.swift
+++ b/readeckTests/Repository/SettingsRepositoryTests.swift
@@ -9,10 +9,10 @@ import Testing
 import Foundation
 @testable import readeck
 
-/// Deckt die CoreData- und UserDefaults-gestützten Pfade ab.
-/// Die Keychain-Felder (endpoint/username/password/token) bleiben ausgespart:
-/// `SettingsRepository` greift dafür fest auf `KeychainHelper.shared` zu, ein Test
-/// würde den echten Keychain des Geräts anfassen.
+/// Covers the CoreData- and UserDefaults-backed paths.
+/// The keychain fields (endpoint/username/password/token) are left out on purpose:
+/// `SettingsRepository` reaches for `KeychainHelper.shared` directly there, so a test
+/// would touch the real device keychain.
 @Suite("SettingsRepository Tests")
 struct SettingsRepositoryTests {
 
@@ -105,12 +105,12 @@ struct SettingsRepositoryTests {
         #expect(loaded.lineHeight == nil)
     }
 
-    // Dokumentiert das Ist-Verhalten, nicht das gewünschte:
-    // loadSettings behandelt einen negativen horizontalMargin als "nicht gesetzt",
-    // der CoreData-Default des Attributs ist aber 0. Sobald irgendeine Einstellung
-    // gespeichert wurde, existiert die SettingEntity und der Margin kommt als 0
-    // zurück statt als nil - der Reader nutzt dann 0 statt der gewollten 16
-    // (siehe FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
+    // Documents the current behaviour, not the desired one:
+    // loadSettings treats a negative horizontalMargin as "not set", but the CoreData
+    // default for the attribute is 0. As soon as any setting has been saved the
+    // SettingEntity exists and the margin comes back as 0 instead of nil - the reader
+    // then uses 0 rather than the intended 16
+    // (see FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
     @Test("known quirk: an untouched horizontalMargin reads back as 0, not nil")
     func untouchedHorizontalMarginReadsAsZero() async throws {
         let (repository, _) = makeRepository()
@@ -198,7 +198,7 @@ struct SettingsRepositoryTests {
         let size = try await repository.getMaxCacheSize()
 
         #expect(size == UInt(200 * 1024 * 1024))
-        // Zweiter Aufruf liest den nun persistierten Wert.
+        // The second call reads the value that has now been persisted.
         #expect(try await repository.getMaxCacheSize() == size)
     }
 }


### PR DESCRIPTION
Neues eigenständiges `URLShareTests`-Target (im readeck-Schema verdrahtet) mit 25 Tests für Offline-Store und Server-nicht-erreichbar-Fallback: `OfflineBookmarkManager`, `TagRepository`, `SimpleAPI`.

Ein eigenes Target ist nötig statt die Dateien in `readeckTests` zu ziehen: `SimpleAPIDTOs` deklariert `ServerInfoDto`, `BookmarkLabelDto` und `CreateBookmarkResponseDto` unter denselben Namen wie das readeck-Modul und würde diese Typen sonst in allen bestehenden Tests überschatten.

Für die Testbarkeit bekommt `OfflineBookmarkManager` seinen CoreDataManager per Init, und Session plus Keychain-Zugriffe von `SimpleAPI` wandern hinter ein injizierbares `SimpleAPIEnvironment`. Beides behält das bisherige Verhalten als Default, die Extension ändert sich zur Laufzeit nicht. `SimpleAPI` nutzt jetzt zusätzlich die konfigurierte HTTPSession aus #82 statt `URLSession.shared`.

Verifiziert: 307 Tests grün (282 readeckTests + 25 URLShareTests), URLShare-Extension baut.

Basiert auf #83 (PR #102).

Closes #84