### PR TITLE
docs: write the remaining code comments in English

### DIFF
--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -133,7 +133,7 @@ final class API: PAPI {
         return (decoded, httpResponse)
     }
 
-    // Separate Methode für JSON-Requests
+    // Separate method for JSON requests
     private func makeJSONRequest<T: Codable>(
         endpoint: String,
         method: HTTPMethod = .GET,
@@ -170,7 +170,7 @@ final class API: PAPI {
         let message: String
     }
 
-    // Separate Methode für String-Requests (HTML/Text)
+    // Separate method for string requests (HTML/text)
     private func makeStringRequest(
         endpoint: String,
         method: HTTPMethod = .GET,
@@ -255,7 +255,7 @@ final class API: PAPI {
         var endpoint = "/api/bookmarks"
         var queryItems: [URLQueryItem] = []
 
-        // Query-Parameter basierend auf State hinzufügen
+        // Add query parameters based on the state
         if let state {
             switch state {
             case .unread:

--- a/readeck/Data/Repository/AuthRepository.swift
+++ b/readeck/Data/Repository/AuthRepository.swift
@@ -13,7 +13,7 @@ final class AuthRepository: PAuthRepository {
 
     func login(endpoint: String, username: String, password: String) async throws -> User {
         let userDto = try await api.login(endpoint: endpoint, username: username, password: password)
-        // Token wird automatisch von der API gespeichert
+        // The token is stored by the API automatically
         await api.tokenProvider.setAuthMethod(.apiToken)
         return User(id: userDto.id, token: userDto.token)
     }

--- a/readeck/Data/Repository/BookmarksRepository.swift
+++ b/readeck/Data/Repository/BookmarksRepository.swift
@@ -51,7 +51,7 @@ final class BookmarksRepository: PBookmarksRepository {
 
         let response = try await api.createBookmark(createRequest: dto)
 
-        // Prüfe ob die Erstellung erfolgreich war
+        // Check whether creation succeeded
         guard response.status == 0 || response.status == 202 else {
             throw CreateBookmarkError.serverError(response.message)
         }

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -289,10 +289,10 @@ final class SettingsRepository: PSettingsRepository {
         // Use TokenProvider to ensure cache is updated
         await tokenProvider.setToken(token)
 
-        // Wenn ein Token gespeichert wird, Setup als abgeschlossen markieren
+        // Storing a token marks the setup as finished
         if !token.isEmpty {
             self.hasFinishedSetup = true
-            // Notification senden, dass sich der Setup-Status geändert hat
+            // Notify that the setup status has changed
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .setupStatusChanged, object: nil)
             }
@@ -327,7 +327,7 @@ final class SettingsRepository: PSettingsRepository {
     func saveHasFinishedSetup(_ hasFinishedSetup: Bool) async throws {
         try await withCheckedThrowingContinuation { continuation in
             self.hasFinishedSetup = hasFinishedSetup
-            // Notification senden, dass sich der Setup-Status geändert hat
+            // Notify that the setup status has changed
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .setupStatusChanged, object: nil)
             }

--- a/readeck/Domain/UseCase/Bookmarks/CreateBookmarkUseCase.swift
+++ b/readeck/Domain/UseCase/Bookmarks/CreateBookmarkUseCase.swift
@@ -24,7 +24,7 @@ final class CreateBookmarkUseCase: PCreateBookmarkUseCase {
         return try await repository.createBookmark(createRequest: createRequest)
     }
 
-    // Convenience methods für häufige Use Cases
+    // Convenience methods for common use cases
     func createFromURL(_ url: String) async throws -> String {
         let request = CreateBookmarkRequest.fromURL(url)
         return try await execute(createRequest: request)
@@ -42,7 +42,7 @@ final class CreateBookmarkUseCase: PCreateBookmarkUseCase {
 
     func createFromClipboard() async throws -> String? {
         nil
-        // URL aus Zwischenablage holen (falls verfügbar)
+        // Read the URL from the pasteboard (if available)
         /*#if canImport(UIKit)
         import UIKit
         guard let clipboardString = UIPasteboard.general.string,

--- a/readeck/Domain/UseCase/Bookmarks/UpdateBookmarkUseCase.swift
+++ b/readeck/Domain/UseCase/Bookmarks/UpdateBookmarkUseCase.swift
@@ -23,7 +23,7 @@ final class UpdateBookmarkUseCase: PUpdateBookmarkUseCase {
         try await repository.updateBookmark(id: bookmarkId, updateRequest: updateRequest)
     }
 
-    // Convenience methods für häufige Aktionen
+    // Convenience methods for common actions
     func toggleArchive(bookmarkId: String, isArchived: Bool) async throws {
         let request = BookmarkUpdateRequest.archive(isArchived)
         try await execute(bookmarkId: bookmarkId, updateRequest: request)

--- a/readeck/Domain/UseCase/Labels/AddLabelsToBookmarkUseCase.swift
+++ b/readeck/Domain/UseCase/Labels/AddLabelsToBookmarkUseCase.swift
@@ -29,13 +29,13 @@ final class AddLabelsToBookmarkUseCase: PAddLabelsToBookmarkUseCase {
         try await repository.updateBookmark(id: bookmarkId, updateRequest: request)
     }
 
-    // Convenience method für einzelne Labels
+    // Convenience method for a single label
     func execute(bookmarkId: String, label: String) async throws {
         try await execute(bookmarkId: bookmarkId, labels: [label])
     }
 }
 
-// Custom error für Label-Operationen
+// Custom error for label operations
 enum BookmarkUpdateError: LocalizedError {
     case emptyLabels
 

--- a/readeck/Domain/UseCase/Labels/RemoveLabelsFromBookmarkUseCase.swift
+++ b/readeck/Domain/UseCase/Labels/RemoveLabelsFromBookmarkUseCase.swift
@@ -29,7 +29,7 @@ final class RemoveLabelsFromBookmarkUseCase: PRemoveLabelsFromBookmarkUseCase {
         try await repository.updateBookmark(id: bookmarkId, updateRequest: request)
     }
 
-    // Convenience method für einzelne Labels
+    // Convenience method for a single label
     func execute(bookmarkId: String, label: String) async throws {
         try await execute(bookmarkId: bookmarkId, labels: [label])
     }

--- a/readeck/UI/BookmarkDetail/BookmarkLabelsViewModel.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkLabelsViewModel.swift
@@ -115,7 +115,7 @@ final class BookmarkLabelsViewModel {
         await removeLabels(from: bookmarkId, labels: [label])
     }
 
-    // Convenience method für das Umschalten eines Labels (hinzufügen wenn nicht vorhanden, entfernen wenn vorhanden)
+    // Convenience method for toggling a label (add when missing, remove when present)
     @MainActor
     func toggleLabel(for bookmarkId: String, label: String) async {
         if currentLabels.contains(label) {

--- a/readeck/UI/Components/CustomHeadersSectionView.swift
+++ b/readeck/UI/Components/CustomHeadersSectionView.swift
@@ -115,7 +115,7 @@ struct CustomHeadersSectionView: View {
                         }
                     }
 
-                    // Add new header - nur wenn nicht im Edit-Modus
+                    // Add new header - only when not in edit mode
                     if editingHeaderKey == nil {
                         InlineHeaderFormView(
                             headerKey: $newHeaderKey,

--- a/readeck/UI/Components/LegacyTagManagementView.swift
+++ b/readeck/UI/Components/LegacyTagManagementView.swift
@@ -250,7 +250,7 @@ struct LegacyTagManagementView: View {
     }
 
     private func calculateMaxHeight() -> Double {
-        // Berechne Höhe für maximal 3 Reihen
+        // Calculate the height for at most 3 rows
         let rowHeight: Double = 32 // Höhe eines Labels
         let spacing: Double = 8
         let maxRows: Double = 3

--- a/readeck/UI/Factory/DefaultUseCaseFactory.swift
+++ b/readeck/UI/Factory/DefaultUseCaseFactory.swift
@@ -44,7 +44,7 @@ protocol UseCaseFactory {
 }
 
 final class DefaultUseCaseFactory: UseCaseFactory {
-    // Eine geteilte, mit Timeouts konfigurierte Session für die ganze App.
+    // One shared session, configured with timeouts, for the whole app.
     private let httpSession: HTTPSession = HTTPSessionFactory.makeDefault()
     private lazy var tokenProvider = KeychainTokenProvider(session: httpSession)
     private lazy var api: PAPI = API(tokenProvider: tokenProvider, session: httpSession)

--- a/readeck/UI/Settings/SettingsContainerView.swift
+++ b/readeck/UI/Settings/SettingsContainerView.swift
@@ -194,7 +194,7 @@ struct SettingsContainerView: View {
     }
 }
 
-// Card Modifier für einheitlichen Look (kept for backwards compatibility with other views)
+// Card modifier for a consistent look (kept for backwards compatibility with other views)
 extension View {
     func cardStyle() -> some View {
         self

--- a/readeck/UI/Utils/URLUtil.swift
+++ b/readeck/UI/Utils/URLUtil.swift
@@ -28,7 +28,7 @@ struct URLUtil {
             safariViewController.preferredBarTintColor = UIColor.systemBackground
             safariViewController.preferredControlTintColor = UIColor.tintColor
 
-            // Finde den präsentierenden View Controller
+            // Find the presenting view controller
             var presentingViewController = rootViewController
             while let presented = presentingViewController.presentedViewController {
                 presentingViewController = presented

--- a/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
+++ b/readeckTests/Integration/HTMLEncodingIntegrationTests.swift
@@ -53,7 +53,7 @@ struct HTMLEncodingIntegrationTests {
 
         let uniqueURL = "https://example.com/utf8-test-\(Int(Date().timeIntervalSince1970))"
 
-        // 1. Bookmark erstellen
+        // 1. Create the bookmark
         let body = try JSONEncoder().encode(CreateRequest(url: uniqueURL, title: "UTF-8 Test", html: html))
 
         var createRequest = URLRequest(url: try #require(URL(string: "\(Config.endpoint)/api/bookmarks")))
@@ -81,7 +81,7 @@ struct HTMLEncodingIntegrationTests {
         let readHttp = try #require(readResponse as? HTTPURLResponse)
         #expect(readHttp.statusCode == 200, "Lesen fehlgeschlagen: \(readHttp.statusCode)")
 
-        // 4. Antwort ausgeben zur Überprüfung
+        // 4. Print the response for inspection
         let responseString = try #require(String(data: data, encoding: .utf8))
         print("📋 Bookmark Response:\n\(responseString)")
 
@@ -89,7 +89,7 @@ struct HTMLEncodingIntegrationTests {
         print("📌 Titel: \(bookmark.title)")
         print("📝 Beschreibung: \(bookmark.description)")
 
-        // 5. Artikel-Content abrufen und UTF-8 prüfen
+        // 5. Fetch the article content and verify UTF-8
         let articleSrc = try #require(bookmark.resources.article?.src, "Kein Artikel-Resource")
         let articleURL = try #require(URL(string: articleSrc))
 


### PR DESCRIPTION
Übersetzt die verbliebenen deutschen Code-Kommentare (23 Zeilen in 15 Dateien), damit die Doku im Code einheitlich englisch ist. Reine Kommentaränderung, kein Verhalten betroffen.

Verifiziert: 307 Tests grün.

Nicht enthalten: In `HTMLEncodingIntegrationTests.swift:105` steht noch eine deutsche Assertion-Message. Das ist ein String, kein Kommentar, daher bewusst ausgelassen.