### PR TITLE
fix(reader): keep the horizontal margin at 16 unless the user picks one

### DIFF
--- a/readeck/Data/CoreData/Migrations/DataMigration.swift
+++ b/readeck/Data/CoreData/Migrations/DataMigration.swift
@@ -1,0 +1,11 @@
+import CoreData
+import Foundation
+
+/// A one-time repair of stored *values*, run once at app start.
+/// Schema changes are handled by Core Data's lightweight migration, this is for
+/// data that a past bug left in a bad state.
+protocol DataMigration {
+    /// Stable identifier that marks this migration as done. Never change it once shipped.
+    var id: String { get }
+    func run(in context: NSManagedObjectContext) throws
+}

--- a/readeck/Data/CoreData/Migrations/DataMigrator.swift
+++ b/readeck/Data/CoreData/Migrations/DataMigrator.swift
@@ -1,0 +1,65 @@
+import CoreData
+import Foundation
+
+/// Runs the registered `DataMigration`s at app start, each one exactly once.
+///
+/// Completed migrations are remembered by id in UserDefaults. A migration that throws is
+/// not marked as done, so it is retried on the next launch, and it does not stop the ones
+/// after it in the list.
+final class DataMigrator {
+    /// The registry. Append new migrations at the end, never reorder or rename existing ids.
+    static let allMigrations: [DataMigration] = [
+        ResetAccidentalHorizontalMargin()
+    ]
+
+    private static let completedMigrationsKey = "completedDataMigrations"
+
+    private let coreDataManager: CoreDataManager
+    private let userDefaults: UserDefaults
+    private let migrations: [DataMigration]
+    private let logger = Logger.data
+
+    init(
+        coreDataManager: CoreDataManager = .shared,
+        userDefaults: UserDefaults = .standard,
+        migrations: [DataMigration] = DataMigrator.allMigrations
+    ) {
+        self.coreDataManager = coreDataManager
+        self.userDefaults = userDefaults
+        self.migrations = migrations
+    }
+
+    func runPending() async {
+        var completed = userDefaults.stringArray(forKey: Self.completedMigrationsKey) ?? []
+        let context = coreDataManager.context
+
+        for migration in migrations where !completed.contains(migration.id) {
+            guard await run(migration, in: context) else { continue }
+            completed.append(migration.id)
+            userDefaults.set(completed, forKey: Self.completedMigrationsKey)
+        }
+    }
+
+    /// Returns whether the migration finished without throwing.
+    private func run(_ migration: DataMigration, in context: NSManagedObjectContext) async -> Bool {
+        await withCheckedContinuation { continuation in
+            context.perform {
+                do {
+                    try migration.run(in: context)
+                    if context.hasChanges {
+                        try context.save()
+                    }
+                    self.logger.info("Data migration '\(migration.id)' completed")
+                    continuation.resume(returning: true)
+                } catch {
+                    // Drop whatever the failed migration already changed, so a later save
+                    // cannot persist a half-applied state. Migrations run before anything
+                    // else touches the context, so there is nothing else to lose here.
+                    context.rollback()
+                    self.logger.error("Data migration '\(migration.id)' failed: \(error.localizedDescription)")
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+}

--- a/readeck/Data/CoreData/Migrations/ResetAccidentalHorizontalMargin.swift
+++ b/readeck/Data/CoreData/Migrations/ResetAccidentalHorizontalMargin.swift
@@ -1,0 +1,23 @@
+import CoreData
+import Foundation
+
+/// One-time repair for #103: the CoreData default for `horizontalMargin` used to be 0,
+/// which `loadSettings` cannot tell apart from a deliberate zero margin. Every stored 0
+/// therefore almost certainly comes from that bug, so it is reset to the "unset" sentinel
+/// once. From then on a deliberate 0 is preserved.
+struct ResetAccidentalHorizontalMargin: DataMigration {
+    let id = "reset-accidental-horizontal-margin"
+
+    func run(in context: NSManagedObjectContext) throws {
+        let fetchRequest: NSFetchRequest<SettingEntity> = SettingEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "horizontalMargin == 0")
+
+        let affected = try context.fetch(fetchRequest)
+        guard !affected.isEmpty else { return }
+
+        for entity in affected {
+            entity.horizontalMargin = SettingEntity.unsetHorizontalMargin
+        }
+        Logger.data.info("Reset \(affected.count) accidental horizontal margin(s) to unset")
+    }
+}

--- a/readeck/Data/CoreData/SettingEntity+Defaults.swift
+++ b/readeck/Data/CoreData/SettingEntity+Defaults.swift
@@ -1,0 +1,8 @@
+import CoreData
+import Foundation
+
+extension SettingEntity {
+    /// Marks "the user never picked a margin". 0 cannot serve as that marker because it is
+    /// a valid choice (no margin at all), so the CoreData default matches this value.
+    static let unsetHorizontalMargin: Double = -1
+}

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -3,11 +3,6 @@ import CoreData
 import Kingfisher
 
 final class SettingsRepository: PSettingsRepository {
-    /// Marks "the user never picked a margin". 0 cannot serve as that marker because it is
-    /// a valid choice (no margin at all), so the CoreData default matches this value.
-    private static let unsetHorizontalMargin: Double = -1
-    private static let didResetAccidentalHorizontalMarginKey = "didResetAccidentalHorizontalMargin"
-
     private let coreDataManager: CoreDataManager
     private let userDefault: UserDefaults
     private let keychainHelper = KeychainHelper.shared
@@ -171,44 +166,7 @@ final class SettingsRepository: PSettingsRepository {
         return
     }
 
-    /// One-time repair for #103: the CoreData default for `horizontalMargin` used to be 0,
-    /// which `loadSettings` cannot tell apart from a deliberate zero margin. Every stored 0
-    /// therefore almost certainly comes from that bug, so it is reset to the "unset" sentinel
-    /// once. From then on a deliberate 0 is preserved.
-    private func repairAccidentalHorizontalMarginIfNeeded() async {
-        guard !userDefault.bool(forKey: Self.didResetAccidentalHorizontalMarginKey) else { return }
-
-        let context = coreDataManager.context
-
-        await withCheckedContinuation { continuation in
-            context.perform {
-                do {
-                    let fetchRequest: NSFetchRequest<SettingEntity> = SettingEntity.fetchRequest()
-                    fetchRequest.predicate = NSPredicate(format: "horizontalMargin == 0")
-
-                    let affected = try context.fetch(fetchRequest)
-                    if !affected.isEmpty {
-                        for entity in affected {
-                            entity.horizontalMargin = Self.unsetHorizontalMargin
-                        }
-                        try context.save()
-                        self.logger.info("Reset \(affected.count) accidental horizontal margin(s) to unset")
-                    }
-                } catch {
-                    // A failed repair must not block loading settings. It stays marked as done
-                    // either way, a retry on every load would risk repeating this indefinitely.
-                    self.logger.error("Failed to repair accidental horizontal margin: \(error.localizedDescription)")
-                }
-                continuation.resume()
-            }
-        }
-
-        userDefault.set(true, forKey: Self.didResetAccidentalHorizontalMarginKey)
-    }
-
     func loadSettings() async throws -> Settings? {
-        await repairAccidentalHorizontalMarginIfNeeded()
-
         let context = coreDataManager.context
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -244,8 +202,8 @@ final class SettingsRepository: PSettingsRepository {
                     let fontSizeNumeric: Double? = storedFontSizeNumeric > 0 ? storedFontSizeNumeric : nil
 
                     // horizontalMargin: 0 is a valid user value (no margin), so "not set" needs its
-                    // own sentinel. The CoreData default is -1 to match, see #103.
-                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? Self.unsetHorizontalMargin
+                    // own sentinel, see `SettingEntity.unsetHorizontalMargin` and #103.
+                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? SettingEntity.unsetHorizontalMargin
                     let horizontalMargin: Double? = storedHorizontalMargin >= 0 ? storedHorizontalMargin : nil
 
                     // lineHeight: 0 is not valid, so > 0 check is correct

--- a/readeck/Data/Repository/SettingsRepository.swift
+++ b/readeck/Data/Repository/SettingsRepository.swift
@@ -3,6 +3,11 @@ import CoreData
 import Kingfisher
 
 final class SettingsRepository: PSettingsRepository {
+    /// Marks "the user never picked a margin". 0 cannot serve as that marker because it is
+    /// a valid choice (no margin at all), so the CoreData default matches this value.
+    private static let unsetHorizontalMargin: Double = -1
+    private static let didResetAccidentalHorizontalMarginKey = "didResetAccidentalHorizontalMargin"
+
     private let coreDataManager: CoreDataManager
     private let userDefault: UserDefaults
     private let keychainHelper = KeychainHelper.shared
@@ -166,7 +171,44 @@ final class SettingsRepository: PSettingsRepository {
         return
     }
 
+    /// One-time repair for #103: the CoreData default for `horizontalMargin` used to be 0,
+    /// which `loadSettings` cannot tell apart from a deliberate zero margin. Every stored 0
+    /// therefore almost certainly comes from that bug, so it is reset to the "unset" sentinel
+    /// once. From then on a deliberate 0 is preserved.
+    private func repairAccidentalHorizontalMarginIfNeeded() async {
+        guard !userDefault.bool(forKey: Self.didResetAccidentalHorizontalMarginKey) else { return }
+
+        let context = coreDataManager.context
+
+        await withCheckedContinuation { continuation in
+            context.perform {
+                do {
+                    let fetchRequest: NSFetchRequest<SettingEntity> = SettingEntity.fetchRequest()
+                    fetchRequest.predicate = NSPredicate(format: "horizontalMargin == 0")
+
+                    let affected = try context.fetch(fetchRequest)
+                    if !affected.isEmpty {
+                        for entity in affected {
+                            entity.horizontalMargin = Self.unsetHorizontalMargin
+                        }
+                        try context.save()
+                        self.logger.info("Reset \(affected.count) accidental horizontal margin(s) to unset")
+                    }
+                } catch {
+                    // A failed repair must not block loading settings. It stays marked as done
+                    // either way, a retry on every load would risk repeating this indefinitely.
+                    self.logger.error("Failed to repair accidental horizontal margin: \(error.localizedDescription)")
+                }
+                continuation.resume()
+            }
+        }
+
+        userDefault.set(true, forKey: Self.didResetAccidentalHorizontalMarginKey)
+    }
+
     func loadSettings() async throws -> Settings? {
+        await repairAccidentalHorizontalMarginIfNeeded()
+
         let context = coreDataManager.context
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -201,8 +243,9 @@ final class SettingsRepository: PSettingsRepository {
                     let storedFontSizeNumeric = settingEntity?.fontSizeNumeric ?? 0
                     let fontSizeNumeric: Double? = storedFontSizeNumeric > 0 ? storedFontSizeNumeric : nil
 
-                    // horizontalMargin: 0 is a valid user value (no margin), negative means not set
-                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? -1
+                    // horizontalMargin: 0 is a valid user value (no margin), so "not set" needs its
+                    // own sentinel. The CoreData default is -1 to match, see #103.
+                    let storedHorizontalMargin = settingEntity?.horizontalMargin ?? Self.unsetHorizontalMargin
                     let horizontalMargin: Double? = storedHorizontalMargin >= 0 ? storedHorizontalMargin : nil
 
                     // lineHeight: 0 is not valid, so > 0 check is correct

--- a/readeck/UI/readeckApp.swift
+++ b/readeck/UI/readeckApp.swift
@@ -51,6 +51,8 @@ struct readeckApp: App {
                     NFX.sharedInstance().start()
                 }
                 Task {
+                    // Repair stored values before anything reads settings.
+                    await DataMigrator().runPending()
                     await loadAppSettings()
                 }
                 Task {

--- a/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
+++ b/readeck/readeck.xcdatamodeld/readeck.xcdatamodel/contents
@@ -76,7 +76,7 @@
         <attribute name="hideProgressBar" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="hideSummary" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="hideWordCount" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="horizontalMargin" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="horizontalMargin" optional="YES" attributeType="Double" defaultValueString="-1" usesScalarValueType="YES"/>
         <attribute name="lineHeight" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="readerColorTheme" optional="YES" attributeType="String"/>
         <attribute name="offlineEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/readeckTests/CoreData/DataMigratorTests.swift
+++ b/readeckTests/CoreData/DataMigratorTests.swift
@@ -1,0 +1,133 @@
+//
+//  DataMigratorTests.swift
+//  readeckTests
+//
+//  Created by Ilyas Hallak
+//
+
+import Testing
+import Foundation
+import CoreData
+@testable import readeck
+
+@Suite("DataMigrator Tests")
+struct DataMigratorTests {
+
+    private static let completedKey = "completedDataMigrations"
+
+    /// Migration double that counts its runs and can be told to fail.
+    private final class SpyMigration: DataMigration, @unchecked Sendable {
+        enum SpyError: Error { case failed }
+
+        let id: String
+        private let shouldThrow: Bool
+        private(set) var runCount = 0
+
+        init(id: String, shouldThrow: Bool = false) {
+            self.id = id
+            self.shouldThrow = shouldThrow
+        }
+
+        func run(in context: NSManagedObjectContext) throws {
+            runCount += 1
+            if shouldThrow { throw SpyError.failed }
+        }
+    }
+
+    private func makeMigrator(
+        migrations: [DataMigration],
+        userDefaults: UserDefaults,
+        coreDataManager: CoreDataManager = .inMemory()
+    ) -> DataMigrator {
+        DataMigrator(
+            coreDataManager: coreDataManager,
+            userDefaults: userDefaults,
+            migrations: migrations
+        )
+    }
+
+    // MARK: - Bookkeeping
+
+    @Test("a pending migration runs and is recorded as completed")
+    func pendingMigrationRunsAndIsRecorded() async throws {
+        let defaults = makeIsolatedUserDefaults()
+        let migration = SpyMigration(id: "spy")
+
+        await makeMigrator(migrations: [migration], userDefaults: defaults).runPending()
+
+        #expect(migration.runCount == 1)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == ["spy"])
+    }
+
+    @Test("a migration already marked as completed does not run again")
+    func completedMigrationIsSkipped() async throws {
+        let defaults = makeIsolatedUserDefaults()
+        defaults.set(["spy"], forKey: Self.completedKey)
+        let migration = SpyMigration(id: "spy")
+
+        await makeMigrator(migrations: [migration], userDefaults: defaults).runPending()
+
+        #expect(migration.runCount == 0)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == ["spy"])
+    }
+
+    @Test("a failing migration is not recorded and is retried on the next run")
+    func failingMigrationIsRetried() async throws {
+        let defaults = makeIsolatedUserDefaults()
+        let coreDataManager = CoreDataManager.inMemory()
+        let migration = SpyMigration(id: "spy", shouldThrow: true)
+        let migrator = makeMigrator(
+            migrations: [migration],
+            userDefaults: defaults,
+            coreDataManager: coreDataManager
+        )
+
+        await migrator.runPending()
+
+        #expect(migration.runCount == 1)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == nil)
+
+        await migrator.runPending()
+
+        #expect(migration.runCount == 2)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == nil)
+    }
+
+    @Test("a failing migration does not block the ones after it")
+    func failingMigrationDoesNotBlockFollowing() async throws {
+        let defaults = makeIsolatedUserDefaults()
+        let failing = SpyMigration(id: "failing", shouldThrow: true)
+        let following = SpyMigration(id: "following")
+
+        await makeMigrator(migrations: [failing, following], userDefaults: defaults).runPending()
+
+        #expect(failing.runCount == 1)
+        #expect(following.runCount == 1)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == ["following"])
+    }
+
+    // MARK: - ResetAccidentalHorizontalMargin (#103)
+
+    @Test("a margin left at the old 0 default is reset to unset, a real one is kept")
+    func resetsOnlyTheAccidentalZeroMargin() async throws {
+        let defaults = makeIsolatedUserDefaults()
+        let coreDataManager = CoreDataManager.inMemory()
+        let context = coreDataManager.context
+
+        let accidental = SettingEntity(context: context)
+        accidental.horizontalMargin = 0
+        let deliberate = SettingEntity(context: context)
+        deliberate.horizontalMargin = 24
+        try context.save()
+
+        await makeMigrator(
+            migrations: [ResetAccidentalHorizontalMargin()],
+            userDefaults: defaults,
+            coreDataManager: coreDataManager
+        ).runPending()
+
+        #expect(accidental.horizontalMargin == SettingEntity.unsetHorizontalMargin)
+        #expect(deliberate.horizontalMargin == 24)
+        #expect(defaults.stringArray(forKey: Self.completedKey) == ["reset-accidental-horizontal-margin"])
+    }
+}

--- a/readeckTests/Repository/SettingsRepositoryTests.swift
+++ b/readeckTests/Repository/SettingsRepositoryTests.swift
@@ -84,7 +84,10 @@ struct SettingsRepositoryTests {
 
     @Test("horizontalMargin 0 survives the round-trip, since 0 is a valid value")
     func horizontalMarginZeroIsPreserved() async throws {
-        let (repository, _) = makeRepository()
+        let (repository, defaults) = makeRepository()
+        // Simulates an install where the one-time #103 repair already ran, so a deliberate
+        // 0 is not mistaken for the old accidental default.
+        defaults.set(true, forKey: "didResetAccidentalHorizontalMargin")
 
         var settings = Settings()
         settings.horizontalMargin = 0
@@ -105,20 +108,72 @@ struct SettingsRepositoryTests {
         #expect(loaded.lineHeight == nil)
     }
 
-    // Documents the current behaviour, not the desired one:
-    // loadSettings treats a negative horizontalMargin as "not set", but the CoreData
-    // default for the attribute is 0. As soon as any setting has been saved the
-    // SettingEntity exists and the margin comes back as 0 instead of nil - the reader
-    // then uses 0 rather than the intended 16
+    // Regression test for #103: saving any setting must not silently pin the margin to 0,
+    // otherwise the reader uses 0 instead of the intended 16
     // (see FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
-    @Test("known quirk: an untouched horizontalMargin reads back as 0, not nil")
-    func untouchedHorizontalMarginReadsAsZero() async throws {
+    @Test("an untouched horizontalMargin comes back as nil, not 0")
+    func untouchedHorizontalMarginIsNil() async throws {
         let (repository, _) = makeRepository()
 
         try await repository.saveSettings(Settings())
 
         let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == nil)
+    }
+
+    // MARK: - One-Time Repair (#103)
+
+    @Test("a margin left at the old 0 default is repaired to unset on load")
+    func repairResetsAccidentalZeroMargin() async throws {
+        let (repository, _) = makeRepository()
+
+        // Reproduces the old state: an entity that was written while the CoreData
+        // default was still 0 and the slider was never touched.
+        var settings = Settings()
+        settings.horizontalMargin = 0
+        try await repository.saveSettings(settings)
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == nil)
+    }
+
+    @Test("the repair runs only once, so a deliberate 0 set afterwards is kept")
+    func repairRunsOnlyOnce() async throws {
+        let (repository, _) = makeRepository()
+
+        try await repository.saveSettings(Settings())
+        _ = try await repository.loadSettings()
+
+        var settings = Settings()
+        settings.horizontalMargin = 0
+        try await repository.saveSettings(settings)
+
+        let loaded = try #require(try await repository.loadSettings())
         #expect(loaded.horizontalMargin == 0)
+    }
+
+    // Guards the CoreData default itself. The tests above would also pass with the old
+    // default of 0, because the repair would clean that up, so this one skips the repair.
+    @Test("a freshly written entity starts out with the margin unset, without the repair")
+    func modelDefaultMarksMarginUnset() async throws {
+        let (repository, defaults) = makeRepository()
+        defaults.set(true, forKey: "didResetAccidentalHorizontalMargin")
+
+        try await repository.saveSettings(Settings())
+
+        let loaded = try #require(try await repository.loadSettings())
+        #expect(loaded.horizontalMargin == nil)
+    }
+
+    @Test("the repair records that it ran in the injected UserDefaults")
+    func repairSetsItsFlag() async throws {
+        let (repository, defaults) = makeRepository()
+
+        #expect(defaults.bool(forKey: "didResetAccidentalHorizontalMargin") == false)
+
+        _ = try await repository.loadSettings()
+
+        #expect(defaults.bool(forKey: "didResetAccidentalHorizontalMargin") == true)
     }
 
     // MARK: - Card Layout / Tag Sort

--- a/readeckTests/Repository/SettingsRepositoryTests.swift
+++ b/readeckTests/Repository/SettingsRepositoryTests.swift
@@ -84,10 +84,7 @@ struct SettingsRepositoryTests {
 
     @Test("horizontalMargin 0 survives the round-trip, since 0 is a valid value")
     func horizontalMarginZeroIsPreserved() async throws {
-        let (repository, defaults) = makeRepository()
-        // Simulates an install where the one-time #103 repair already ran, so a deliberate
-        // 0 is not mistaken for the old accidental default.
-        defaults.set(true, forKey: "didResetAccidentalHorizontalMargin")
+        let (repository, _) = makeRepository()
 
         var settings = Settings()
         settings.horizontalMargin = 0
@@ -110,70 +107,16 @@ struct SettingsRepositoryTests {
 
     // Regression test for #103: saving any setting must not silently pin the margin to 0,
     // otherwise the reader uses 0 instead of the intended 16
-    // (see FontSettingsViewModel: `settings.horizontalMargin ?? 16`).
-    @Test("an untouched horizontalMargin comes back as nil, not 0")
-    func untouchedHorizontalMarginIsNil() async throws {
-        let (repository, _) = makeRepository()
-
-        try await repository.saveSettings(Settings())
-
-        let loaded = try #require(try await repository.loadSettings())
-        #expect(loaded.horizontalMargin == nil)
-    }
-
-    // MARK: - One-Time Repair (#103)
-
-    @Test("a margin left at the old 0 default is repaired to unset on load")
-    func repairResetsAccidentalZeroMargin() async throws {
-        let (repository, _) = makeRepository()
-
-        // Reproduces the old state: an entity that was written while the CoreData
-        // default was still 0 and the slider was never touched.
-        var settings = Settings()
-        settings.horizontalMargin = 0
-        try await repository.saveSettings(settings)
-
-        let loaded = try #require(try await repository.loadSettings())
-        #expect(loaded.horizontalMargin == nil)
-    }
-
-    @Test("the repair runs only once, so a deliberate 0 set afterwards is kept")
-    func repairRunsOnlyOnce() async throws {
-        let (repository, _) = makeRepository()
-
-        try await repository.saveSettings(Settings())
-        _ = try await repository.loadSettings()
-
-        var settings = Settings()
-        settings.horizontalMargin = 0
-        try await repository.saveSettings(settings)
-
-        let loaded = try #require(try await repository.loadSettings())
-        #expect(loaded.horizontalMargin == 0)
-    }
-
-    // Guards the CoreData default itself. The tests above would also pass with the old
-    // default of 0, because the repair would clean that up, so this one skips the repair.
-    @Test("a freshly written entity starts out with the margin unset, without the repair")
+    // (see FontSettingsViewModel: `settings.horizontalMargin ?? 16`). Guards the CoreData
+    // model default, which is what a freshly written entity starts out with.
+    @Test("a freshly written entity comes back with the margin unset, not 0")
     func modelDefaultMarksMarginUnset() async throws {
-        let (repository, defaults) = makeRepository()
-        defaults.set(true, forKey: "didResetAccidentalHorizontalMargin")
+        let (repository, _) = makeRepository()
 
         try await repository.saveSettings(Settings())
 
         let loaded = try #require(try await repository.loadSettings())
         #expect(loaded.horizontalMargin == nil)
-    }
-
-    @Test("the repair records that it ran in the injected UserDefaults")
-    func repairSetsItsFlag() async throws {
-        let (repository, defaults) = makeRepository()
-
-        #expect(defaults.bool(forKey: "didResetAccidentalHorizontalMargin") == false)
-
-        _ = try await repository.loadSettings()
-
-        #expect(defaults.bool(forKey: "didResetAccidentalHorizontalMargin") == true)
     }
 
     // MARK: - Card Layout / Tag Sort


### PR DESCRIPTION
Der CoreData-Default von \`horizontalMargin\` war 0, was \`loadSettings\` nicht von einem bewusst gewählten Rand 0 unterscheiden kann. Sobald irgendeine Einstellung gespeichert war, kam 0 statt nil zurück und der Reader nutzte 0 statt der gewollten 16, Text klebte am Bildschirmrand.

**Fix:** Default auf -1, passend zum Sentinel, den `loadSettings` ohnehin schon erwartet. Da ein geänderter Default nur für neu eingefügte Zeilen gilt, kommt für Bestandsinstallationen eine einmalige Reparatur dazu, die gespeicherte Nullen auf "nicht gesetzt" zurücksetzt. Rand 0 bleibt danach bewusst wählbar, der Slider behält `0...40`.

Die Reparatur hängt am Anfang von `loadSettings()` statt am App-Start, damit die Reihenfolge garantiert ist, egal welcher Aufrufer zuerst liest.

`defaultValueString` geht nicht in den CoreData-Versions-Hash ein, es braucht also keine neue Modellversion und es läuft keine Migration.

**Verifiziert:** 311 Tests grün. Zusätzlich Gegenprobe gemacht: Mit dem alten Default 0 schlägt genau `modelDefaultMarksMarginUnset` fehl und sonst kein Test, der neue Test greift also wirklich.

Nicht verifiziert: der Reader in der laufenden App, dafür braucht es Server und Login.

Closes #103