### PR TITLE
feat(bookmarks): favorite status in list, swipe menu and unread

### DIFF
--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -259,8 +259,9 @@ final class API: PAPI {
         if let state {
             switch state {
             case .unread:
+                // Unread means "not archived" only. A favorite can be unread too,
+                // matching the web app, so it is not filtered out here.
                 queryItems.append(URLQueryItem(name: "is_archived", value: "false"))
-                queryItems.append(URLQueryItem(name: "is_marked", value: "false"))
             case .favorite:
                 queryItems.append(URLQueryItem(name: "is_marked", value: "true"))
             case .archived:

--- a/readeck/Data/API/API.swift
+++ b/readeck/Data/API/API.swift
@@ -259,8 +259,6 @@ final class API: PAPI {
         if let state {
             switch state {
             case .unread:
-                // Unread means "not archived" only. A favorite can be unread too,
-                // matching the web app, so it is not filtered out here.
                 queryItems.append(URLQueryItem(name: "is_archived", value: "false"))
             case .favorite:
                 queryItems.append(URLQueryItem(name: "is_marked", value: "true"))

--- a/readeck/Domain/Model/SwipeAction.swift
+++ b/readeck/Domain/Model/SwipeAction.swift
@@ -24,7 +24,8 @@ enum SwipeAction: String, Codable, CaseIterable, Identifiable {
     var iconName: String {
         switch self {
         case .archive: return "archivebox"
-        case .favorite: return "heart.fill"
+        // Outline, not filled: a filled heart reads as "already a favorite"
+        case .favorite: return "heart"
         case .delete: return "trash"
         case .showTags: return "tag"
         case .openInBrowser: return "safari"

--- a/readeck/Domain/Model/SwipeAction.swift
+++ b/readeck/Domain/Model/SwipeAction.swift
@@ -24,7 +24,6 @@ enum SwipeAction: String, Codable, CaseIterable, Identifiable {
     var iconName: String {
         switch self {
         case .archive: return "archivebox"
-        // Outline, not filled: a filled heart reads as "already a favorite"
         case .favorite: return "heart"
         case .delete: return "trash"
         case .showTags: return "tag"

--- a/readeck/Domain/UseCase/Badge/UpdateUnreadBadgeUseCase.swift
+++ b/readeck/Domain/UseCase/Badge/UpdateUnreadBadgeUseCase.swift
@@ -4,7 +4,7 @@
 //
 //  Business logic for the unread app-icon badge (opt-in, off by default).
 //
-//  The count mirrors the app's "Unread" tab (not archived, not favorited) and is
+//  The count mirrors the app's "Unread" tab (not archived; favorites count too) and is
 //  read cheaply from the `Total-Count` header via a `limit: 1` bookmarks request —
 //  no dedicated endpoint or full fetch. Applying the value goes through the
 //  `PAppBadgeService` output port, keeping the platform API out of the domain.

--- a/readeck/Domain/UseCase/Bookmarks/GetBookmarksUseCase.swift
+++ b/readeck/Domain/UseCase/Bookmarks/GetBookmarksUseCase.swift
@@ -22,7 +22,7 @@ final class GetBookmarksUseCase: PGetBookmarksUseCase {
                 case .all:
                     return true
                 case .unread:
-                    return !bookmark.isArchived && !bookmark.isMarked
+                    return !bookmark.isArchived
                 case .favorite:
                     return bookmark.isMarked
                 case .archived:

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -299,3 +299,16 @@
 "The Readeck Project" = "Das Readeck-Projekt";
 "Creator of Readeck" = "Schöpfer von Readeck";
 "Thanks to everyone who has contributed to the app." = "Danke an alle, die zur App beigetragen haben.";
+
+/* Onboarding */
+"Enter your Readeck server" = "Readeck-Server eingeben";
+"Enter your server endpoint to get started." = "Gib deinen Server-Endpunkt ein, um loszulegen.";
+"HTTP/HTTPS supported. HTTP only for local networks. Port optional. No trailing slash needed." = "HTTP/HTTPS werden unterstützt. HTTP nur für lokale Netzwerke. Port optional. Kein Schrägstrich am Ende nötig.";
+"Custom HTTP Headers" = "Eigene HTTP-Header";
+"Continue" = "Weiter";
+"Checking..." = "Wird geprüft...";
+"Retrying..." = "Erneuter Versuch...";
+"Enter your credentials" = "Zugangsdaten eingeben";
+"Please provide your username and password." = "Bitte gib Benutzername und Passwort ein.";
+"Logging in..." = "Anmeldung läuft...";
+"Use username & password instead" = "Stattdessen Benutzername & Passwort verwenden";

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -803,8 +803,8 @@ struct ArticleReaderLegacyView: View {
                     }
                 }) {
                     HStack {
-                        Image(systemName: viewModel.bookmarkDetail.isMarked ? "star.fill" : "star")
-                            .foregroundColor(viewModel.bookmarkDetail.isMarked ? .yellow : .gray)
+                        Image(systemName: viewModel.bookmarkDetail.isMarked ? "heart.fill" : "heart")
+                            .foregroundColor(viewModel.bookmarkDetail.isMarked ? .pink : .gray)
                         Text(viewModel.bookmarkDetail.isMarked ? "Favorite" : "Mark as favorite")
                     }
                     .font(.title3.bold())

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -148,8 +148,8 @@ struct ArticleReaderView: View {
                         await viewModel.toggleFavorite(id: bookmarkId)
                     }
                 }) {
-                    Image(systemName: viewModel.bookmarkDetail.isMarked ? "star.fill" : "star")
-                        .foregroundStyle(viewModel.bookmarkDetail.isMarked ? .yellow : .primary)
+                    Image(systemName: viewModel.bookmarkDetail.isMarked ? "heart.fill" : "heart")
+                        .foregroundStyle(viewModel.bookmarkDetail.isMarked ? .pink : .primary)
                         .frame(width: 52.0, height: 52.0)
                         .font(.system(size: 31))
                 }

--- a/readeck/UI/Bookmarks/BookmarkCardView.swift
+++ b/readeck/UI/Bookmarks/BookmarkCardView.swift
@@ -155,13 +155,10 @@ struct BookmarkCardView: View {
             Button {
                 onSwipeAction(.favorite, bookmark)
             } label: {
-                if bookmark.isMarked {
-                    Image(systemName: "heart.slash")
-                } else {
-                    Image(systemName: "heart.fill")
-                }
+                // The icon mirrors the current state, not the action, to match the web app
+                Label("Favorite", systemImage: bookmark.isMarked ? "heart.fill" : "heart")
             }
-            .tint(bookmark.isMarked ? .gray : .pink)
+            .tint(.pink)
 
         case .delete:
             Button(role: .destructive) {
@@ -198,6 +195,7 @@ struct BookmarkCardView: View {
                 .scaledToFill()
                 .frame(width: 80, height: 80)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(alignment: .topTrailing) { favoriteBadge(diameter: 22, padding: 4) }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(bookmark.title)
@@ -252,8 +250,9 @@ struct BookmarkCardView: View {
                     .scaledToFill()
                     .frame(height: 140)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(alignment: .topTrailing) { favoriteBadge() }
 
-                if bookmark.readProgress > 0 && bookmark.isArchived == false && bookmark.isMarked == false {
+                if bookmark.readProgress > 0 && bookmark.isArchived == false {
                     ZStack {
                         Circle()
                             .fill(Color(.systemBackground))
@@ -337,8 +336,9 @@ struct BookmarkCardView: View {
                     .frame(width: UIScreen.main.bounds.width - 32)
                     .clipped()
                     .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(alignment: .topTrailing) { favoriteBadge() }
 
-                if bookmark.readProgress > 0 && bookmark.isArchived == false && bookmark.isMarked == false {
+                if bookmark.readProgress > 0 && bookmark.isArchived == false {
                     ZStack {
                         Circle()
                             .fill(Color(.systemBackground))
@@ -412,6 +412,23 @@ struct BookmarkCardView: View {
 
     // MARK: - Computed Properties
 
+    /// Marks a favorite on the bookmark image, styled like the read progress badge
+    @ViewBuilder
+    private func favoriteBadge(diameter: Double = 28, padding: Double = 8) -> some View {
+        if bookmark.isMarked {
+            ZStack {
+                Circle()
+                    .fill(Color(.systemBackground))
+                    .frame(width: diameter, height: diameter)
+                Image(systemName: "heart.fill")
+                    .font(.system(size: diameter / 2))
+                    .foregroundStyle(.pink)
+            }
+            .padding(padding)
+            .accessibilityLabel("Favorite")
+        }
+    }
+
     private var formattedPublishedDate: String? {
         guard let published = bookmark.published, !published.isEmpty else {
             return nil
@@ -479,18 +496,5 @@ struct BookmarkCardView: View {
             return URL(string: imageUrl)
         }
         return nil
-    }
-}
-
-struct IconBadge: View {
-    let systemName: String
-    let color: Color
-
-    var body: some View {
-        Image(systemName: systemName)
-            .frame(width: 20, height: 20)
-            .background(color)
-            .foregroundColor(.white)
-            .clipShape(Circle())
     }
 }

--- a/readeck/UI/Bookmarks/BookmarkCardView.swift
+++ b/readeck/UI/Bookmarks/BookmarkCardView.swift
@@ -155,8 +155,11 @@ struct BookmarkCardView: View {
             Button {
                 onSwipeAction(.favorite, bookmark)
             } label: {
-                // The icon mirrors the current state, not the action, to match the web app
+                // The icon mirrors the current state, not the action, to match the web app.
+                // symbolVariants is pinned because containers such as lists otherwise
+                // force the fill variant, which would make both states look identical.
                 Label("Favorite", systemImage: bookmark.isMarked ? "heart.fill" : "heart")
+                    .environment(\.symbolVariants, .none)
             }
             .tint(.pink)
 

--- a/readeck/UI/Bookmarks/BookmarkCardView.swift
+++ b/readeck/UI/Bookmarks/BookmarkCardView.swift
@@ -155,9 +155,6 @@ struct BookmarkCardView: View {
             Button {
                 onSwipeAction(.favorite, bookmark)
             } label: {
-                // The icon mirrors the current state, not the action, to match the web app.
-                // symbolVariants is pinned because containers such as lists otherwise
-                // force the fill variant, which would make both states look identical.
                 Label("Favorite", systemImage: bookmark.isMarked ? "heart.fill" : "heart")
                     .environment(\.symbolVariants, .none)
             }
@@ -415,7 +412,6 @@ struct BookmarkCardView: View {
 
     // MARK: - Computed Properties
 
-    /// Marks a favorite on the bookmark image, styled like the read progress badge
     @ViewBuilder
     private func favoriteBadge(diameter: Double = 28, padding: Double = 8) -> some View {
         if bookmark.isMarked {

--- a/readeck/UI/Onboarding/OnboardingServerView.swift
+++ b/readeck/UI/Onboarding/OnboardingServerView.swift
@@ -72,7 +72,6 @@ struct OnboardingServerView: View {
         return !viewModel.endpoint.isEmpty
     }
 
-    // LocalizedStringKey, not String: Text(String) skips the localization lookup
     private var buttonTitle: LocalizedStringKey {
         if viewModel.isLoading {
             if showLoginFields { return "Logging in..." }

--- a/readeck/UI/Onboarding/OnboardingServerView.swift
+++ b/readeck/UI/Onboarding/OnboardingServerView.swift
@@ -72,7 +72,8 @@ struct OnboardingServerView: View {
         return !viewModel.endpoint.isEmpty
     }
 
-    private var buttonTitle: String {
+    // LocalizedStringKey, not String: Text(String) skips the localization lookup
+    private var buttonTitle: LocalizedStringKey {
         if viewModel.isLoading {
             if showLoginFields { return "Logging in..." }
             return oauthFailed ? "Retrying..." : "Checking..."

--- a/readeck/UI/Settings/SwipeActionsSettingsView.swift
+++ b/readeck/UI/Settings/SwipeActionsSettingsView.swift
@@ -76,6 +76,7 @@ struct SwipeActionsDetailView: View {
                 ForEach(config.leadingActions) { action in
                     HStack {
                         Image(systemName: action.iconName)
+                            .environment(\.symbolVariants, .none)
                             .foregroundColor(.accentColor)
                             .frame(width: 24)
                         Text(action.displayName)
@@ -114,6 +115,7 @@ struct SwipeActionsDetailView: View {
                 ForEach(config.trailingActions) { action in
                     HStack {
                         Image(systemName: action.iconName)
+                            .environment(\.symbolVariants, .none)
                             .foregroundColor(.accentColor)
                             .frame(width: 24)
                         Text(action.displayName)
@@ -189,6 +191,7 @@ struct SwipeActionsDetailView: View {
                     } label: {
                         HStack {
                             Image(systemName: action.iconName)
+                                .environment(\.symbolVariants, .none)
                                 .foregroundColor(.accentColor)
                                 .frame(width: 24)
                             Text(action.displayName)

--- a/readeckTests/UseCases/GetBookmarksUseCaseTests.swift
+++ b/readeckTests/UseCases/GetBookmarksUseCaseTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+@testable import readeck
+
+@Suite("GetBookmarksUseCase state filter")
+struct GetBookmarksUseCaseTests {
+
+    // MARK: - Fakes
+
+    private final class StubBookmarksRepository: PBookmarksRepository {
+        var bookmarks: [Bookmark] = []
+
+        // swiftlint:disable:next discouraged_optional_collection
+        func fetchBookmarks(state: BookmarkState?, limit: Int?, offset: Int?, search: String?, type: [BookmarkType]?, tag: String?, sort: String?) async throws -> BookmarksPage {
+            BookmarksPage(bookmarks: bookmarks, currentPage: 1, totalCount: bookmarks.count, totalPages: 1, links: nil)
+        }
+
+        func fetchBookmark(id: String) async throws -> BookmarkDetail { fatalError("unused") }
+        func fetchBookmarkArticle(id: String) async throws -> String { fatalError("unused") }
+        func createBookmark(createRequest: CreateBookmarkRequest) async throws -> String { fatalError("unused") }
+        func updateBookmark(id: String, updateRequest: BookmarkUpdateRequest) async throws {}
+        func deleteBookmark(id: String) async throws {}
+        func searchBookmarks(search: String) async throws -> BookmarksPage { fatalError("unused") }
+    }
+
+    private func bookmark(id: String, isArchived: Bool = false, isMarked: Bool = false) -> Bookmark {
+        Bookmark(
+            id: id,
+            title: "Title \(id)",
+            url: "https://example.com/\(id)",
+            href: "https://api.example.com/bookmarks/\(id)",
+            description: "",
+            authors: [],
+            created: "",
+            published: nil,
+            updated: "",
+            siteName: "example.com",
+            site: "https://example.com",
+            readingTime: 5,
+            wordCount: 100,
+            hasArticle: true,
+            isArchived: isArchived,
+            isDeleted: false,
+            isMarked: isMarked,
+            labels: [],
+            lang: "en",
+            loaded: true,
+            readProgress: 0,
+            documentType: "article",
+            state: 0,
+            textDirection: "ltr",
+            type: "article",
+            resources: BookmarkResources(article: nil, icon: nil, image: nil, log: nil, props: nil, thumbnail: nil)
+        )
+    }
+
+    private func makeSUT() -> (GetBookmarksUseCase, StubBookmarksRepository) {
+        let repository = StubBookmarksRepository()
+        repository.bookmarks = [
+            bookmark(id: "plain"),
+            bookmark(id: "favorite", isMarked: true),
+            bookmark(id: "archived", isArchived: true),
+            bookmark(id: "archivedFavorite", isArchived: true, isMarked: true)
+        ]
+        return (GetBookmarksUseCase(repository: repository), repository)
+    }
+
+    @Test("Unread keeps favorites, because a favorite can still be unread")
+    func unreadKeepsFavorites() async throws {
+        let (sut, _) = makeSUT()
+
+        let page = try await sut.execute(state: .unread)
+
+        #expect(page.bookmarks.map(\.id) == ["plain", "favorite"])
+    }
+
+    @Test("Unread still drops everything archived")
+    func unreadDropsArchived() async throws {
+        let (sut, _) = makeSUT()
+
+        let page = try await sut.execute(state: .unread)
+
+        #expect(page.bookmarks.allSatisfy { !$0.isArchived })
+    }
+
+    @Test("Favorite returns every marked bookmark, archived or not")
+    func favoriteReturnsMarked() async throws {
+        let (sut, _) = makeSUT()
+
+        let page = try await sut.execute(state: .favorite)
+
+        #expect(page.bookmarks.map(\.id) == ["favorite", "archivedFavorite"])
+    }
+
+    @Test("Archived returns every archived bookmark")
+    func archivedReturnsArchived() async throws {
+        let (sut, _) = makeSUT()
+
+        let page = try await sut.execute(state: .archived)
+
+        #expect(page.bookmarks.map(\.id) == ["archived", "archivedFavorite"])
+    }
+
+    @Test("All applies no filter")
+    func allKeepsEverything() async throws {
+        let (sut, _) = makeSUT()
+
+        let page = try await sut.execute(state: .all)
+
+        #expect(page.bookmarks.count == 4)
+    }
+}


### PR DESCRIPTION
Closes #76, closes #77.

- Herz spiegelt den Status statt der Aktion, in Swipe-Menü und Reader
- Favoriten-Badge auf der Karte, alle drei Layouts
- Lesefortschritt verschwindet nicht mehr bei Favoriten
- Ungelesen versteckt keine Favoriten mehr (wie readeck-Web), Badge zählt sie mit
- Nebenbei: deutsche Onboarding-Strings vervollständigt