### PR TITLE
fix: reader scroll performance and font size persistence

### DIFF
--- a/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
+++ b/readeck/Domain/UseCase/Settings/SaveSettingsUseCase.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 protocol PSaveSettingsUseCase {
-    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize) async throws
-    func execute(selectedFontFamily: FontFamily, fontSizeNumeric: Double) async throws
+    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize, fontSizeNumeric: Double) async throws
     func execute(readerLayout horizontalMargin: Double, lineHeight: Double) async throws
     func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool, hideSummary: Bool) async throws
     func execute(customCSS: String) async throws
@@ -24,19 +23,11 @@ final class SaveSettingsUseCase: PSaveSettingsUseCase {
         self.settingsRepository = settingsRepository
     }
 
-    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize) async throws {
+    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize, fontSizeNumeric: Double) async throws {
         try await settingsRepository.saveSettings(
             .init(
                 fontFamily: selectedFontFamily,
-                fontSize: selectedFontSize
-            )
-        )
-    }
-
-    func execute(selectedFontFamily: FontFamily, fontSizeNumeric: Double) async throws {
-        try await settingsRepository.saveSettings(
-            .init(
-                fontFamily: selectedFontFamily,
+                fontSize: selectedFontSize,
                 fontSizeNumeric: fontSizeNumeric
             )
         )

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -1,14 +1,6 @@
 import SwiftUI
 import SafariServices
 
-// PreferenceKey for scroll offset tracking
-struct ScrollOffsetPreferenceKey: PreferenceKey {
-    static var defaultValue: CGPoint = .zero
-    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {
-        value = nextValue()
-    }
-}
-
 // PreferenceKey for content height tracking
 struct ContentHeightPreferenceKey: PreferenceKey {
     static var defaultValue: Double = 0
@@ -25,7 +17,6 @@ struct ArticleReaderLegacyView: View {
 
     @State private var viewModel: BookmarkDetailViewModel
     @State private var webViewHeight: Double = 300
-    @State private var contentEndPosition: Double = 0
     @State private var initialContentEndPosition: Double = 0
     @State private var showingFontSettings = false
     @State private var showingLabelsSheet = false
@@ -50,177 +41,6 @@ struct ArticleReaderLegacyView: View {
         self.viewModel = viewModel
     }
 
-    @ViewBuilder
-    private func scrollViewContent(geometry: GeometryProxy) -> some View {
-        // Invisible GeometryReader to track scroll offset
-        GeometryReader { scrollGeo in
-            Color.clear.preference(
-                key: ScrollOffsetPreferenceKey.self,
-                value: CGPoint(
-                    x: scrollGeo.frame(in: .named("scrollView")).minX,
-                    y: scrollGeo.frame(in: .named("scrollView")).minY
-                )
-            )
-        }
-        .frame(height: 0)
-
-        VStack(spacing: 0) {
-            ZStack(alignment: .top) {
-                headerView(width: geometry.size.width)
-                VStack(alignment: .leading, spacing: 16) {
-                Color.clear.frame(width: geometry.size.width, height: viewModel.hasVisibleHeroImage ? headerHeight : 84)
-                titleSection
-                Divider().padding(.horizontal)
-                if showJumpToProgressButton {
-                    JumpButton(containerHeight: geometry.size.height)
-                }
-                if let settings = viewModel.settings, !viewModel.articleContent.isEmpty {
-                    WebView(
-                        htmlContent: viewModel.articleContent,
-                        settings: settings,
-                        onHeightChange: { height in
-                            if webViewHeight != height {
-                                webViewHeight = height
-                            }
-                        },
-                        selectedAnnotationId: viewModel.selectedAnnotationId,
-                        onAnnotationCreated: { color, text, startOffset, endOffset, startSelector, endSelector in
-                            Task {
-                                await viewModel.createAnnotation(
-                                    bookmarkId: bookmarkId,
-                                    color: color,
-                                    text: text,
-                                    startOffset: startOffset,
-                                    endOffset: endOffset,
-                                    startSelector: startSelector,
-                                    endSelector: endSelector
-                                )
-                            }
-                        },
-                        onScrollToPosition: { position in
-                            // Calculate scroll position: add header height and webview offset
-                            let imageHeight: Double = viewModel.hasVisibleHeroImage ? headerHeight : 84
-                            let targetPosition = imageHeight + position
-
-                            // Scroll to the annotation
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                scrollPosition = ScrollPosition(y: targetPosition)
-                            }
-                        }
-                    )
-                    .frame(height: webViewHeight)
-                    .cornerRadius(14)
-                    .padding(.horizontal, 4)
-                } else if viewModel.isLoadingArticle {
-                    ProgressView("Loading article...")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding()
-                } else {
-                    Button(action: {
-                        URLUtil.open(url: viewModel.bookmarkDetail.url, urlOpener: appSettings.urlOpener)
-                    }) {
-                        HStack {
-                            Image(systemName: "safari")
-                            Text(URLUtil.openUrlLabel(for: viewModel.bookmarkDetail.url))
-                        }
-                        .font(.title3.bold())
-                        .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .padding(.horizontal)
-                    .padding(.top, 0)
-                }
-
-                if viewModel.isLoadingArticle == false && viewModel.isLoading == false {
-                    VStack {
-                        archiveSection
-                            .transition(.opacity.combined(with: .move(edge: .bottom)))
-                            .animation(.easeInOut, value: viewModel.articleContent)
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-                }
-            .frame(maxWidth: .infinity)
-            }
-
-            // Invisible marker to measure total content height - placed AFTER all content
-            Color.clear
-                .frame(height: 1)
-                .background(
-                    GeometryReader { endGeo in
-                        Color.clear.preference(
-                            key: ContentHeightPreferenceKey.self,
-                            value: endGeo.frame(in: .named("scrollView")).maxY
-                        )
-                    }
-                )
-        }
-    }
-
-    @ViewBuilder
-    private func scrollableContent(geometry: GeometryProxy) -> some View {
-        ScrollView {
-            scrollViewContent(geometry: geometry)
-        }
-        .coordinateSpace(name: "scrollView")
-        .clipped()
-        .ignoresSafeArea(edges: .top)
-        .scrollPosition($scrollPosition)
-        .disableScrollBounce()
-        .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
-            contentEndPosition = endPosition
-
-            let containerHeight = geometry.size.height
-
-            // Update initial position if content grows (WebView still loading) or first time
-            // We always take the maximum position seen (when scrolled to top, this is total content height)
-            if endPosition > initialContentEndPosition && endPosition > containerHeight * 1.2 {
-                initialContentEndPosition = endPosition
-                Logger.ui.debug("Content end position updated: \(Int(endPosition)) (container: \(Int(containerHeight)))")
-            }
-
-            // Calculate progress from how much the end marker has moved up
-            guard initialContentEndPosition > 0 else {
-                Logger.ui.debug("Waiting for content to load... current: \(Int(endPosition)), container: \(Int(containerHeight))")
-                return
-            }
-
-            let totalScrollableDistance = initialContentEndPosition - containerHeight
-
-            guard totalScrollableDistance > 0 else {
-                Logger.ui.debug("Content not scrollable: initial=\(initialContentEndPosition), container=\(containerHeight)")
-                return
-            }
-
-            // How far has the marker moved from its initial position?
-            let scrolled = initialContentEndPosition - endPosition
-            let rawProgress = scrolled / totalScrollableDistance
-            var progress = min(max(rawProgress, 0), 1)
-
-            // Lock progress at 100% once reached (don't go back to 99% due to pixel variations)
-            if lastSentProgress >= 0.995 {
-                progress = max(progress, 1.0)
-            }
-
-            Logger.ui.debug("Progress: \(Int(progress * 100))% | scrolled: \(Int(scrolled)) / \(Int(totalScrollableDistance)) | endPos: \(Int(endPosition))")
-
-            // Check if we should update: threshold OR reaching 100% for first time
-            let threshold = 0.03
-            let reachedEnd = progress >= 1.0 && lastSentProgress < 1.0
-            let shouldUpdate = abs(progress - lastSentProgress) >= threshold || reachedEnd
-
-            if shouldUpdate {
-                Logger.ui.debug("Updating progress: \(Int(lastSentProgress * 100))% → \(Int(progress * 100))%\(reachedEnd ? " [END]" : "")")
-                lastSentProgress = progress
-                readingProgress = progress
-                viewModel.debouncedUpdateReadProgress(id: bookmarkId, progress: progress, anchor: nil)
-            }
-        }
-        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { _ in
-            // Not needed anymore, we track via ContentHeightPreferenceKey
-        }
-    }
-
     var body: some View {
         mainContent
             .frame(maxWidth: .infinity)
@@ -236,18 +56,6 @@ struct ArticleReaderLegacyView: View {
             }
             GeometryReader { geometry in
                 ScrollView {
-                    // Invisible GeometryReader to track scroll offset
-                    GeometryReader { scrollGeo in
-                        Color.clear.preference(
-                            key: ScrollOffsetPreferenceKey.self,
-                            value: CGPoint(
-                                x: scrollGeo.frame(in: .named("scrollView")).minX,
-                                y: scrollGeo.frame(in: .named("scrollView")).minY
-                            )
-                        )
-                    }
-                    .frame(height: 0)
-
                     VStack(spacing: 0) {
                         ZStack(alignment: .top) {
                             if viewModel.showHeroImage {
@@ -348,8 +156,6 @@ struct ArticleReaderLegacyView: View {
                 .ignoresSafeArea(edges: .top)
                 .scrollPosition($scrollPosition)
                 .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
-                    contentEndPosition = endPosition
-
                     let containerHeight = geometry.size.height
 
                     // Update initial position if content grows (WebView still loading) or first time
@@ -395,9 +201,6 @@ struct ArticleReaderLegacyView: View {
                         readingProgress = progress
                         viewModel.debouncedUpdateReadProgress(id: bookmarkId, progress: progress, anchor: nil)
                     }
-                }
-                .onPreferenceChange(ScrollOffsetPreferenceKey.self) { _ in
-                    // Not needed anymore, we track via ContentHeightPreferenceKey
                 }
             }
         }

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -10,7 +10,6 @@ struct ArticleReaderView: View {
 
     @State private var viewModel: BookmarkDetailViewModel
     @State private var webViewHeight: Double = 300
-    @State private var contentEndPosition: Double = 0
     @State private var showingFontSettings = false
     @State private var showingLabelsSheet = false
     @State private var showingAnnotationsSheet = false
@@ -219,8 +218,6 @@ struct ArticleReaderView: View {
             .scrollPosition($scrollPosition)
             .disableScrollBounce()
             .onPreferenceChange(ContentHeightPreferenceKey.self) { endPosition in
-                contentEndPosition = endPosition
-
                 let result = scrollTracker.update(endPosition: endPosition, containerHeight: geometry.size.height)
 
                 if let progress = result.readingProgress {

--- a/readeck/UI/Components/ReaderFontCSSBuilder.swift
+++ b/readeck/UI/Components/ReaderFontCSSBuilder.swift
@@ -7,7 +7,27 @@ struct ReaderFontCSSBuildResult {
 }
 
 enum ReaderFontCSSBuilder {
+    private static let cacheLock = NSLock()
+    private static var cache: [FontFamily: ReaderFontCSSBuildResult] = [:]
+
     static func build(fontFamily: FontFamily) -> ReaderFontCSSBuildResult {
+        cacheLock.lock()
+        let cached = cache[fontFamily]
+        cacheLock.unlock()
+        if let cached {
+            return cached
+        }
+
+        let result = makeResult(fontFamily: fontFamily)
+
+        cacheLock.lock()
+        cache[fontFamily] = result
+        cacheLock.unlock()
+
+        return result
+    }
+
+    private static func makeResult(fontFamily: FontFamily) -> ReaderFontCSSBuildResult {
         let fallbackStack = fallbackFontStack(for: fontFamily)
 
         guard let fileNames = fontFamily.fontFileNames,

--- a/readeck/UI/Components/WebView.swift
+++ b/readeck/UI/Components/WebView.swift
@@ -54,6 +54,20 @@ struct WebView: UIViewRepresentable {
         let lineHeightValue = settings.lineHeight ?? 1.4
         let selectedFontFamily = settings.fontFamily ?? .serif
 
+        var renderHasher = Hasher()
+        renderHasher.combine(htmlContent)
+        renderHasher.combine(settings.webViewIdentifier)
+        renderHasher.combine(fontSize)
+        renderHasher.combine(horizontalMargin)
+        renderHasher.combine(lineHeightValue)
+        renderHasher.combine(selectedFontFamily.rawValue)
+        renderHasher.combine(isDarkMode)
+        renderHasher.combine(selectedAnnotationId)
+        let renderKey = renderHasher.finalize()
+
+        guard context.coordinator.lastRenderKey != renderKey else { return }
+        context.coordinator.lastRenderKey = renderKey
+
         // Resolve color theme
         let colorTheme = settings.readerColorTheme ?? .system
         let resolvedBgColor: String
@@ -736,6 +750,9 @@ final class WebViewCoordinator: NSObject, WKNavigationDelegate, WKScriptMessageH
 
     // WebView reference
     weak var webView: WKWebView?
+
+    // Identifies the currently rendered document, so unrelated view updates don't reload it
+    var lastRenderKey: Int?
 
     // Height management
     var lastHeight: Double = 0

--- a/readeck/UI/Factory/MockUseCaseFactory.swift
+++ b/readeck/UI/Factory/MockUseCaseFactory.swift
@@ -232,8 +232,7 @@ final class MockSaveSettingsUseCase: PSaveSettingsUseCase {
     func execute(endpoint: String, username: String, password: String) async throws {}
     func execute(endpoint: String, username: String, password: String, hasFinishedSetup: Bool) async throws {}
     func execute(token: String) async throws {}
-    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize) async throws {}
-    func execute(selectedFontFamily: FontFamily, fontSizeNumeric: Double) async throws {}
+    func execute(selectedFontFamily: FontFamily, selectedFontSize: FontSize, fontSizeNumeric: Double) async throws {}
     func execute(readerLayout horizontalMargin: Double, lineHeight: Double) async throws {}
     func execute(readerVisibility hideProgressBar: Bool, hideWordCount: Bool, hideHeroImage: Bool, hideSummary: Bool) async throws {}
     func execute(customCSS: String) async throws {}

--- a/readeck/UI/Settings/FontSettingsViewModel.swift
+++ b/readeck/UI/Settings/FontSettingsViewModel.swift
@@ -232,6 +232,7 @@ final class FontSettingsViewModel {
         do {
             try await saveSettingsUseCase.execute(
                 selectedFontFamily: selectedFontFamily,
+                selectedFontSize: selectedFontSize,
                 fontSizeNumeric: fontSizeNumeric
             )
         } catch {

--- a/readeckTests/Settings/FontSizePersistenceTests.swift
+++ b/readeckTests/Settings/FontSizePersistenceTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import readeck
+
+@Suite("Font size persistence")
+struct FontSizePersistenceTests {
+
+    @Test("Saving font settings persists the font size enum alongside the numeric value")
+    func savesFontSizeEnumAndNumeric() async throws {
+        let repository = RecordingSettingsRepository()
+        let useCase = SaveSettingsUseCase(settingsRepository: repository)
+
+        try await useCase.execute(
+            selectedFontFamily: .system,
+            selectedFontSize: .large,
+            fontSizeNumeric: Double(FontSize.large.size)
+        )
+
+        let saved = try #require(repository.savedSettings.last)
+        #expect(saved.fontSize == .large)
+        #expect(saved.fontSizeNumeric == Double(FontSize.large.size))
+        #expect(saved.fontFamily == .system)
+    }
+
+    @Test("A custom numeric size still persists the matching enum case")
+    func savesCustomFontSize() async throws {
+        let repository = RecordingSettingsRepository()
+        let useCase = SaveSettingsUseCase(settingsRepository: repository)
+
+        try await useCase.execute(
+            selectedFontFamily: .literata,
+            selectedFontSize: .custom,
+            fontSizeNumeric: 23
+        )
+
+        let saved = try #require(repository.savedSettings.last)
+        #expect(saved.fontSize == .custom)
+        #expect(saved.fontSizeNumeric == 23)
+    }
+}


### PR DESCRIPTION
Fixes #78.

**Scroll performance:** `updateUIView` reloaded the full article HTML on every SwiftUI view update, and the font CSS re-read and base64-encoded the TTF files each time (1.44 MB for Lato alone). Both now only run when something that affects the document changed. Also drops a scroll preference that fired on every frame into an empty handler, and a dead duplicate of the progress logic that nothing called.

**Font size:** picking a size stored only `fontSizeNumeric`, never the `FontSize` enum, so `loadSettings` fell back to `.medium` and reopening the settings sheet showed the old value — saving from there reverted the change. Both fields are persisted now, covered by a regression test.

Tests: 294 + 25, all green. Verified on device (iPhone 17 Pro).

Note: the sluggish scrolling could not be reproduced end-to-end — it does not occur on an iPhone 17 Pro. The reported device is an iPhone 12, so the fix is based on measured cost per reload rather than an observed frame drop.