### PR TITLE
Factory injection for two view models + error path tests

### DIFF
--- a/readeck/UI/AddBookmark/AddBookmarkViewModel.swift
+++ b/readeck/UI/AddBookmark/AddBookmarkViewModel.swift
@@ -5,10 +5,17 @@ import UIKit
 final class AddBookmarkViewModel {
     // MARK: - Dependencies
 
-    private let createBookmarkUseCase = DefaultUseCaseFactory.shared.makeCreateBookmarkUseCase()
-    private let getLabelsUseCase = DefaultUseCaseFactory.shared.makeGetLabelsUseCase()
-    private let createLabelUseCase = DefaultUseCaseFactory.shared.makeCreateLabelUseCase()
-    private let syncTagsUseCase = DefaultUseCaseFactory.shared.makeSyncTagsUseCase()
+    private let createBookmarkUseCase: PCreateBookmarkUseCase
+    private let getLabelsUseCase: PGetLabelsUseCase
+    private let createLabelUseCase: PCreateLabelUseCase
+    private let syncTagsUseCase: PSyncTagsUseCase
+
+    init(_ factory: UseCaseFactory = DefaultUseCaseFactory.shared) {
+        self.createBookmarkUseCase = factory.makeCreateBookmarkUseCase()
+        self.getLabelsUseCase = factory.makeGetLabelsUseCase()
+        self.createLabelUseCase = factory.makeCreateLabelUseCase()
+        self.syncTagsUseCase = factory.makeSyncTagsUseCase()
+    }
 
     // MARK: - Form Data
     var url = ""

--- a/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
+++ b/readeck/UI/BookmarkDetail/BookmarkDetailViewModel.swift
@@ -225,7 +225,7 @@ final class BookmarkDetailViewModel {
         errorMessage = nil
         do {
             try await updateBookmarkUseCase.toggleArchive(bookmarkId: id, isArchived: isArchive)
-            bookmarkDetail.isArchived = true
+            bookmarkDetail.isArchived = isArchive
             if isArchive {
                 NotificationCenter.default.post(
                     name: .bookmarkArchived,

--- a/readeck/UI/Bookmarks/BookmarksViewModel.swift
+++ b/readeck/UI/Bookmarks/BookmarksViewModel.swift
@@ -465,6 +465,7 @@ final class BookmarksViewModel {
                 errorMessage = formatServerErrorMessage(statusCode: statusCode)
                 logger.error("Server error with status code: \(statusCode)")
             case .serverErrorWithMessage(statusCode: let statusCode, message: let message):
+                errorMessage = message.isEmpty ? formatServerErrorMessage(statusCode: statusCode) : message
                 logger.error("Server error with status code: \(statusCode), and message: \(message)")
             }
             isNetworkError = false

--- a/readeck/UI/Search/SearchBookmarksViewModel.swift
+++ b/readeck/UI/Search/SearchBookmarksViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @Observable
 final class SearchBookmarksViewModel {
-    private let searchBookmarksUseCase = DefaultUseCaseFactory.shared.makeSearchBookmarksUseCase()
+    private let searchBookmarksUseCase: PSearchBookmarksUseCase
 
     var searchQuery = "" {
         didSet {
@@ -16,6 +16,10 @@ final class SearchBookmarksViewModel {
     var errorMessage: String?
 
     private var searchWorkItem: DispatchWorkItem?
+
+    init(_ factory: UseCaseFactory = DefaultUseCaseFactory.shared) {
+        self.searchBookmarksUseCase = factory.makeSearchBookmarksUseCase()
+    }
 
     private func throttleSearch() {
         searchWorkItem?.cancel()

--- a/readeckTests/Helpers/ConfigurableMocks.swift
+++ b/readeckTests/Helpers/ConfigurableMocks.swift
@@ -110,6 +110,63 @@ class ConfigurableCreateBookmarkUseCase: PCreateBookmarkUseCase {
     func createFromClipboard() async throws -> String? { try result.get() }
 }
 
+class ConfigurableGetCachedArticleUseCase: PGetCachedArticleUseCase {
+    /// `nil` by default so tests exercise the server path instead of the bundled sample article.
+    var result: String?
+
+    func execute(id: String) -> String? { result }
+}
+
+class ConfigurableGetCachedBookmarksUseCase: PGetCachedBookmarksUseCase {
+    var result: Result<[Bookmark], Error> = .success([.mock])
+    var executeCalled = false
+
+    func execute() async throws -> [Bookmark] {
+        executeCalled = true
+        return try result.get()
+    }
+}
+
+class ConfigurableGetBookmarkAnnotationsUseCase: PGetBookmarkAnnotationsUseCase {
+    var result: Result<[Annotation], Error> = .success([])
+
+    func execute(bookmarkId: String) async throws -> [Annotation] { try result.get() }
+}
+
+class ConfigurableCreateAnnotationUseCase: PCreateAnnotationUseCase {
+    var result: Result<Annotation, Error> = .success(
+        Annotation(id: "annotation-1", text: "highlighted", created: "", startOffset: 0, endOffset: 1, startSelector: "", endSelector: "")
+    )
+
+    func execute(bookmarkId: String, color: String, startOffset: Int, endOffset: Int, startSelector: String, endSelector: String) async throws -> Annotation {
+        try result.get()
+    }
+
+    func execute(bookmarkId: String, text: String, startOffset: Int, endOffset: Int, startSelector: String, endSelector: String) async throws {
+        _ = try result.get()
+    }
+}
+
+class ConfigurableLogoutUseCase: PLogoutUseCase {
+    var result: Result<Void, Error> = .success(())
+    var executeCount = 0
+    var executeCalled: Bool { executeCount > 0 }
+
+    func execute() async throws {
+        executeCount += 1
+        try result.get()
+    }
+}
+
+class ConfigurableUpdateUnreadBadgeUseCase: PUpdateUnreadBadgeUseCase {
+    var refreshCount = 0
+
+    func refresh() async { refreshCount += 1 }
+
+    @discardableResult
+    func setEnabled(_ enabled: Bool) async -> Bool { true }
+}
+
 class ConfigurableSummarizeArticleUseCase: PSummarizeArticleUseCase {
     static var isAvailable: Bool { true }
     var result: Result<String, Error> = .success("Test summary")

--- a/readeckTests/Helpers/TestUseCaseFactory.swift
+++ b/readeckTests/Helpers/TestUseCaseFactory.swift
@@ -14,6 +14,12 @@ class TestUseCaseFactory: UseCaseFactory {
     let mockCreateBookmark = ConfigurableCreateBookmarkUseCase()
     let mockSettingsRepository = MockSettingsRepository()
     let mockSummarizeArticle = ConfigurableSummarizeArticleUseCase()
+    let mockGetCachedArticle = ConfigurableGetCachedArticleUseCase()
+    let mockGetCachedBookmarks = ConfigurableGetCachedBookmarksUseCase()
+    let mockGetAnnotations = ConfigurableGetBookmarkAnnotationsUseCase()
+    let mockCreateAnnotation = ConfigurableCreateAnnotationUseCase()
+    let mockLogout = ConfigurableLogoutUseCase()
+    let mockUpdateUnreadBadge = ConfigurableUpdateUnreadBadgeUseCase()
 
     // Configurable use cases
     func makeLoginUseCase() -> PLoginUseCase { mockLogin }
@@ -25,11 +31,16 @@ class TestUseCaseFactory: UseCaseFactory {
     func makeCreateBookmarkUseCase() -> PCreateBookmarkUseCase { mockCreateBookmark }
     func makeCheckServerReachabilityUseCase() -> PCheckServerReachabilityUseCase { mockCheckReachability }
     func makeGetServerInfoUseCase() -> PGetServerInfoUseCase { MockGetServerInfoUseCase() }
+    func makeGetCachedArticleUseCase() -> PGetCachedArticleUseCase { mockGetCachedArticle }
+    func makeGetCachedBookmarksUseCase() -> PGetCachedBookmarksUseCase { mockGetCachedBookmarks }
+    func makeGetBookmarkAnnotationsUseCase() -> PGetBookmarkAnnotationsUseCase { mockGetAnnotations }
+    func makeCreateAnnotationUseCase() -> PCreateAnnotationUseCase { mockCreateAnnotation }
+    func makeLogoutUseCase() -> PLogoutUseCase { mockLogout }
+    func makeUpdateUnreadBadgeUseCase() -> PUpdateUnreadBadgeUseCase { mockUpdateUnreadBadge }
 
     // Non-configurable — use existing mocks from MockUseCaseFactory pattern
     func makeSaveSettingsUseCase() -> PSaveSettingsUseCase { MockSaveSettingsUseCase() }
     func makeLoadSettingsUseCase() -> PLoadSettingsUseCase { MockLoadSettingsUseCase() }
-    func makeLogoutUseCase() -> PLogoutUseCase { MockLogoutUseCase() }
     func makeSearchBookmarksUseCase() -> PSearchBookmarksUseCase { MockSearchBookmarksUseCase() }
     func makeSaveServerSettingsUseCase() -> PSaveServerSettingsUseCase { MockSaveServerSettingsUseCase() }
     func makeAddLabelsToBookmarkUseCase() -> PAddLabelsToBookmarkUseCase { MockAddLabelsToBookmarkUseCase() }
@@ -41,14 +52,10 @@ class TestUseCaseFactory: UseCaseFactory {
     func makeOfflineBookmarkSyncUseCase() -> POfflineBookmarkSyncUseCase { MockOfflineBookmarkSyncUseCase() }
     func makeLoadCardLayoutUseCase() -> PLoadCardLayoutUseCase { MockLoadCardLayoutUseCase() }
     func makeSaveCardLayoutUseCase() -> PSaveCardLayoutUseCase { MockSaveCardLayoutUseCase() }
-    func makeGetBookmarkAnnotationsUseCase() -> PGetBookmarkAnnotationsUseCase { MockGetBookmarkAnnotationsUseCase() }
     func makeDeleteAnnotationUseCase() -> PDeleteAnnotationUseCase { MockDeleteAnnotationUseCase() }
     func makeSettingsRepository() -> PSettingsRepository { mockSettingsRepository }
     func makeOfflineCacheSyncUseCase() -> POfflineCacheSyncUseCase { MockOfflineCacheSyncUseCase() }
     func makeNetworkMonitorUseCase() -> PNetworkMonitorUseCase { MockNetworkMonitorUseCase() }
-    func makeGetCachedBookmarksUseCase() -> PGetCachedBookmarksUseCase { MockGetCachedBookmarksUseCase() }
-    func makeGetCachedArticleUseCase() -> PGetCachedArticleUseCase { MockGetCachedArticleUseCase() }
-    func makeCreateAnnotationUseCase() -> PCreateAnnotationUseCase { MockCreateAnnotationUseCase() }
     func makeGetCacheSizeUseCase() -> PGetCacheSizeUseCase { MockGetCacheSizeUseCase() }
     func makeGetMaxCacheSizeUseCase() -> PGetMaxCacheSizeUseCase { MockGetMaxCacheSizeUseCase() }
     func makeUpdateMaxCacheSizeUseCase() -> PUpdateMaxCacheSizeUseCase { MockUpdateMaxCacheSizeUseCase() }
@@ -57,5 +64,4 @@ class TestUseCaseFactory: UseCaseFactory {
     func makeLoginWithOAuthUseCase() -> PLoginWithOAuthUseCase { MockLoginWithOAuthUseCase() }
     func makeAuthRepository() -> PAuthRepository { MockAuthRepository() }
     func makeSummarizeArticleUseCase() -> PSummarizeArticleUseCase { mockSummarizeArticle }
-    func makeUpdateUnreadBadgeUseCase() -> PUpdateUnreadBadgeUseCase { MockUpdateUnreadBadgeUseCase() }
 }

--- a/readeckTests/ViewModels/AppViewModelTests.swift
+++ b/readeckTests/ViewModels/AppViewModelTests.swift
@@ -9,7 +9,9 @@ import Testing
 import Foundation
 @testable import readeck
 
-@Suite("AppViewModel Tests")
+/// Serialized because the tests drive the view model through app-wide
+/// NotificationCenter events, which would otherwise cross between parallel cases.
+@Suite("AppViewModel Tests", .serialized)
 @MainActor
 struct AppViewModelTests {
 
@@ -63,9 +65,84 @@ struct AppViewModelTests {
         // Post the unauthorized notification
         NotificationCenter.default.post(name: .unauthorizedAPIResponse, object: nil)
 
-        // Wait for the async handler to complete
-        try await Task.sleep(nanoseconds: 500_000_000)
+        await waitUntil { vm.hasFinishedSetup == false }
 
         #expect(vm.hasFinishedSetup == false)
+        #expect(factory.mockLogout.executeCalled == true)
+    }
+
+    @Test("A failing logout is swallowed and does not block later attempts")
+    func unauthorizedNotification_logoutFailureIsRecoverable() async throws {
+        let factory = TestUseCaseFactory()
+        factory.mockLogout.result = .failure(TestError.networkError)
+        let vm = AppViewModel(factory: factory)
+
+        NotificationCenter.default.post(name: .unauthorizedAPIResponse, object: nil)
+        await waitUntil { factory.mockLogout.executeCount == 1 }
+
+        // A second 401 must still trigger a logout attempt.
+        factory.mockLogout.result = .success(())
+        NotificationCenter.default.post(name: .unauthorizedAPIResponse, object: nil)
+        await waitUntil { factory.mockLogout.executeCount == 2 }
+
+        #expect(factory.mockLogout.executeCount == 2)
+        withExtendedLifetime(vm) {}
+    }
+
+    // MARK: - Setup Status
+
+    @Test("setupStatusChanged notification reloads the setup status")
+    func setupStatusChangedNotification_reloadsSetup() async {
+        let factory = TestUseCaseFactory()
+        factory.mockSettingsRepository.hasFinishedSetup = false
+        let vm = AppViewModel(factory: factory)
+        #expect(vm.hasFinishedSetup == false)
+
+        factory.mockSettingsRepository.hasFinishedSetup = true
+        NotificationCenter.default.post(name: .setupStatusChanged, object: nil)
+
+        await waitUntil { vm.hasFinishedSetup }
+
+        #expect(vm.hasFinishedSetup == true)
+    }
+
+    // MARK: - Unread Badge
+
+    @Test("Archiving or deleting a bookmark refreshes the unread badge")
+    func bookmarkMutationNotifications_refreshBadge() async {
+        let factory = TestUseCaseFactory()
+        // Must stay alive: the observers capture the view model weakly.
+        let vm = AppViewModel(factory: factory)
+
+        NotificationCenter.default.post(name: .bookmarkArchived, object: nil, userInfo: ["id": "1"])
+        await waitUntil { factory.mockUpdateUnreadBadge.refreshCount >= 1 }
+        #expect(factory.mockUpdateUnreadBadge.refreshCount >= 1)
+
+        NotificationCenter.default.post(name: .bookmarkDeleted, object: nil, userInfo: ["id": "1"])
+        await waitUntil { factory.mockUpdateUnreadBadge.refreshCount >= 2 }
+        #expect(factory.mockUpdateUnreadBadge.refreshCount >= 2)
+
+        withExtendedLifetime(vm) {}
+    }
+
+    @Test("Resuming the app refreshes the unread badge")
+    func onAppResume_refreshesBadge() async {
+        let factory = TestUseCaseFactory()
+        let vm = AppViewModel(factory: factory)
+
+        await vm.onAppResume()
+
+        #expect(factory.mockUpdateUnreadBadge.refreshCount >= 1)
+    }
+
+    // MARK: - Helpers
+
+    /// Polls until `condition` holds instead of sleeping for a fixed interval,
+    /// so notification-driven tests neither flake nor pay a fixed delay.
+    private func waitUntil(timeout: TimeInterval = 2, _ condition: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 }

--- a/readeckTests/ViewModels/BookmarkDetailViewModelTests.swift
+++ b/readeckTests/ViewModels/BookmarkDetailViewModelTests.swift
@@ -148,4 +148,165 @@ struct BookmarkDetailViewModelTests {
 
         #expect(receivedId == "789")
     }
+
+    // MARK: - Article Content Error Paths
+
+    @Test("Article load failure sets error and stops the loading indicator")
+    func loadArticleContentFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetCachedArticle.result = nil
+        factory.mockGetBookmarkArticle.result = .failure(TestError.networkError)
+
+        await vm.loadArticleContent(id: "456")
+
+        #expect(vm.errorMessage == "Error loading article")
+        #expect(vm.articleContent.isEmpty)
+        #expect(vm.isLoadingArticle == false)
+    }
+
+    @Test("A cached article is served even when the server is unreachable")
+    func loadArticleContentFallsBackToCache() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetCachedArticle.result = "<p>Cached</p>"
+        factory.mockGetBookmarkArticle.result = .failure(TestError.networkError)
+
+        await vm.loadArticleContent(id: "456")
+
+        #expect(vm.articleContent == "<p>Cached</p>")
+        #expect(vm.errorMessage == nil)
+        #expect(vm.isLoadingArticle == false)
+    }
+
+    // MARK: - Bookmark Detail Error Paths
+
+    @Test("Failing annotations do not break loading the bookmark itself")
+    func loadBookmarkDetailToleratesAnnotationFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetAnnotations.result = .failure(TestError.networkError)
+
+        await vm.loadBookmarkDetail(id: "456")
+
+        // Annotations are supplementary — the article must still open.
+        #expect(vm.bookmarkDetail.id == "123")
+        #expect(vm.annotations.isEmpty)
+        #expect(vm.errorMessage == nil)
+    }
+
+    // MARK: - Archive
+
+    @Test("Un-archiving clears the archived flag instead of setting it")
+    func unarchiveClearsArchivedFlag() async {
+        let (vm, _) = createSUT()
+        await vm.archiveBookmark(id: "456", isArchive: true)
+        #expect(vm.bookmarkDetail.isArchived == true)
+
+        await vm.archiveBookmark(id: "456", isArchive: false)
+
+        // The flag used to be hardcoded to true, so the reader's toggle stayed
+        // on "archived" after un-archiving.
+        #expect(vm.bookmarkDetail.isArchived == false)
+    }
+
+    @Test("Archive failure sets an error and leaves the flag untouched")
+    func archiveBookmarkFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockUpdateBookmark.result = .failure(TestError.networkError)
+
+        await vm.archiveBookmark(id: "456")
+
+        #expect(vm.errorMessage == "Error archiving bookmark")
+        #expect(vm.bookmarkDetail.isArchived == false)
+        #expect(vm.isLoading == false)
+    }
+
+    // MARK: - Favorite
+
+    @Test("Toggle favorite flips the flag")
+    func toggleFavoriteSuccess() async {
+        let (vm, factory) = createSUT()
+
+        await vm.toggleFavorite(id: "456")
+
+        #expect(factory.mockUpdateBookmark.toggleFavoriteCalled == true)
+        #expect(vm.bookmarkDetail.isMarked == true)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("Favorite failure sets an error and leaves the flag untouched")
+    func toggleFavoriteFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockUpdateBookmark.result = .failure(TestError.networkError)
+
+        await vm.toggleFavorite(id: "456")
+
+        #expect(vm.errorMessage == "Error updating favorite status")
+        #expect(vm.bookmarkDetail.isMarked == false)
+        #expect(vm.isLoading == false)
+    }
+
+    // MARK: - Read Progress
+
+    @Test("Read progress is not pushed backwards")
+    func updateReadProgressIgnoresLowerValue() async {
+        let (vm, factory) = createSUT()
+        vm.readProgress = 80
+
+        await vm.updateReadProgress(id: "456", progress: 20, anchor: nil)
+
+        #expect(factory.mockUpdateBookmark.updateProgressCalled == false)
+    }
+
+    // MARK: - Annotations
+
+    @Test("Creating an annotation appends it and pulls the annotated HTML")
+    func createAnnotationSuccess() async {
+        let (vm, factory) = createSUT()
+        // The server re-renders the article with the highlight markup afterwards.
+        factory.mockGetBookmarkArticle.result = .success("<p><rd-annotation>highlighted</rd-annotation></p>")
+
+        await vm.createAnnotation(bookmarkId: "456", color: "yellow", text: "highlighted", startOffset: 0, endOffset: 5, startSelector: "p", endSelector: "p")
+
+        #expect(vm.annotations.count == 1)
+        #expect(vm.hasAnnotations == true)
+        #expect(vm.articleContent.contains("rd-annotation"))
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("Annotation failure sets a generic error message")
+    func createAnnotationFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockCreateAnnotation.result = .failure(TestError.networkError)
+
+        await vm.createAnnotation(bookmarkId: "456", color: "yellow", text: "highlighted", startOffset: 0, endOffset: 5, startSelector: "p", endSelector: "p")
+
+        #expect(vm.errorMessage == "Error creating highlight")
+        #expect(vm.annotations.isEmpty)
+    }
+
+    @Test("Overlapping annotations get their own error message")
+    func createAnnotationOverlapError() async {
+        let (vm, factory) = createSUT()
+        factory.mockCreateAnnotation.result = .failure(
+            APIError.serverErrorWithMessage(statusCode: 422, message: "annotation is overlapping an existing one")
+        )
+
+        await vm.createAnnotation(bookmarkId: "456", color: "yellow", text: "highlighted", startOffset: 0, endOffset: 5, startSelector: "p", endSelector: "p")
+
+        #expect(vm.errorMessage == "This text overlaps with an existing highlight")
+    }
+
+    // MARK: - Share Content
+
+    @Test("Share text combines title, URL and annotations")
+    func shareContentIncludesAnnotations() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetAnnotations.result = .success([
+            Annotation(id: "1", text: "first note", created: "", startOffset: 0, endOffset: 1, startSelector: "", endSelector: "")
+        ])
+
+        await vm.loadBookmarkDetail(id: "456")
+
+        #expect(vm.shareContent.contains("https://example.com"))
+        #expect(vm.shareContent.contains("first note"))
+    }
 }

--- a/readeckTests/ViewModels/BookmarksViewModelTests.swift
+++ b/readeckTests/ViewModels/BookmarksViewModelTests.swift
@@ -133,4 +133,176 @@ struct BookmarksViewModelTests {
         // Clean up: cancel the pending delete to avoid background task leaking
         vm.undoDelete(bookmarkId: bookmark.id)
     }
+
+    // MARK: - Error Mapping
+
+    @Test("Network-level errors are flagged as network errors")
+    func loadBookmarksNetworkErrorSetsNetworkFlag() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(URLError(.notConnectedToInternet))
+
+        await vm.loadBookmarks()
+
+        #expect(vm.isNetworkError == true)
+        #expect(vm.errorMessage == "No internet connection")
+    }
+
+    @Test("Other URLErrors are not flagged as network errors")
+    func loadBookmarksOtherURLErrorKeepsNetworkFlagOff() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(URLError(.badServerResponse))
+
+        await vm.loadBookmarks()
+
+        #expect(vm.isNetworkError == false)
+        #expect(vm.errorMessage?.hasPrefix("Network error") == true)
+    }
+
+    @Test("401 maps to a session-expired message")
+    func loadBookmarksUnauthorizedMessage() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(APIError.serverError(401))
+
+        await vm.loadBookmarks()
+
+        #expect(vm.errorMessage == "Session expired. Please log in again.")
+        #expect(vm.isNetworkError == false)
+    }
+
+    @Test("5xx maps to a retryable server error message")
+    func loadBookmarksServerErrorMessage() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(APIError.serverError(503))
+
+        await vm.loadBookmarks()
+
+        #expect(vm.errorMessage == "Server error (code: 503). Please try again later.")
+    }
+
+    @Test("Invalid URL maps to a settings hint")
+    func loadBookmarksInvalidURLMessage() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(APIError.invalidURL)
+
+        await vm.loadBookmarks()
+
+        #expect(vm.errorMessage == "Invalid server URL. Please check your settings.")
+    }
+
+    @Test("Server errors carrying a message surface that message instead of failing silently")
+    func loadBookmarksServerErrorWithMessageIsSurfaced() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(
+            APIError.serverErrorWithMessage(statusCode: 422, message: "Invalid sort field")
+        )
+
+        await vm.loadBookmarks()
+
+        // Used to leave errorMessage nil, so the list looked healthy while nothing loaded.
+        #expect(vm.errorMessage == "Invalid sort field")
+    }
+
+    @Test("A failed reload keeps the previously loaded bookmarks visible")
+    func loadBookmarksFailureKeepsExistingData() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .success(
+            BookmarksPage(bookmarks: [.mock], currentPage: 1, totalCount: 1, totalPages: 1, links: nil)
+        )
+        await vm.loadBookmarks()
+
+        factory.mockGetBookmarks.result = .failure(TestError.networkError)
+        await vm.loadBookmarks()
+
+        #expect(vm.bookmarks?.bookmarks.count == 1)
+        #expect(vm.errorMessage != nil)
+    }
+
+    @Test("Retrying clears the previous error state")
+    func retryLoadingClearsErrorState() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .failure(URLError(.notConnectedToInternet))
+        await vm.loadBookmarks()
+        #expect(vm.isNetworkError == true)
+
+        factory.mockGetBookmarks.result = .success(
+            BookmarksPage(bookmarks: [.mock], currentPage: 1, totalCount: 1, totalPages: 1, links: nil)
+        )
+        await vm.retryLoading()
+
+        #expect(vm.errorMessage == nil)
+        #expect(vm.isNetworkError == false)
+    }
+
+    // MARK: - Mutation Error Paths
+
+    @Test("Archive failure sets an error message")
+    func toggleArchiveFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockUpdateBookmark.result = .failure(TestError.networkError)
+
+        await vm.toggleArchive(bookmark: .mock)
+
+        #expect(vm.errorMessage == "Error archiving bookmark")
+    }
+
+    @Test("Favorite failure sets an error message")
+    func toggleFavoriteFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockUpdateBookmark.result = .failure(TestError.networkError)
+
+        await vm.toggleFavorite(bookmark: .mock)
+
+        #expect(vm.errorMessage == "Error marking bookmark")
+    }
+
+    @Test("Reset read progress failure sets an error message")
+    func resetReadProgressFailure() async {
+        let (vm, factory) = createSUT()
+        factory.mockUpdateBookmark.result = .failure(TestError.networkError)
+
+        await vm.resetReadProgress(bookmark: .mock)
+
+        #expect(vm.errorMessage == "Error resetting reading progress")
+    }
+
+    // MARK: - Offline Fallback
+
+    @Test("Offline load falls back to cached bookmarks")
+    func loadCachedBookmarksFromUIUsesCache() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetCachedBookmarks.result = .success([.mock])
+
+        await vm.loadCachedBookmarksFromUI()
+
+        #expect(factory.mockGetCachedBookmarks.executeCalled == true)
+        #expect(vm.bookmarks?.bookmarks.count == 1)
+        #expect(vm.isNetworkError == true)
+        #expect(vm.errorMessage == "No internet connection")
+    }
+
+    @Test("Offline fallback only reads the cache on the Unread tab")
+    func cachedBookmarksSkippedOutsideUnread() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetBookmarks.result = .success(
+            BookmarksPage(bookmarks: [.mock], currentPage: 1, totalCount: 1, totalPages: 1, links: nil)
+        )
+        await vm.loadBookmarks(state: .archived)
+
+        await vm.loadCachedBookmarksFromUI()
+
+        // Only the Unread list is cached for offline use; the other tabs must not
+        // silently show unread items.
+        #expect(factory.mockGetCachedBookmarks.executeCalled == false)
+    }
+
+    @Test("A failing cache read leaves the offline error message in place")
+    func cachedBookmarksFailureKeepsOfflineMessage() async {
+        let (vm, factory) = createSUT()
+        factory.mockGetCachedBookmarks.result = .failure(TestError.networkError)
+
+        await vm.loadCachedBookmarksFromUI()
+
+        #expect(vm.bookmarks == nil)
+        #expect(vm.errorMessage == "No internet connection")
+    }
 }


### PR DESCRIPTION
Closes #88, closes #85.

- #88: SearchBookmarks/AddBookmark VMs take the UseCaseFactory via init instead of reaching for the shared singleton.
- #85: error and edge-case coverage for Bookmarks, BookmarkDetail and App view models (26 new tests).

Two bugs surfaced while writing the tests and are fixed here:
- Un-archiving from the reader left `isArchived` stuck at true.
- `APIError.serverErrorWithMessage` was logged but never shown to the user.