### PR TITLE
Stop a finished article from blocking the speech queue

### DIFF
--- a/readeck/UI/Menu/PhoneTabView.swift
+++ b/readeck/UI/Menu/PhoneTabView.swift
@@ -46,6 +46,9 @@ struct PhoneTabView: View {
                         MiniPlayerView(viewModel: speechPlayerViewModel, onTap: {
                             isPlayerSheetPresented = true
                         }, onClose: {
+                            // Closing the player ends playback; hiding it while the
+                            // voice keeps reading leaves no way to stop it.
+                            speechPlayerViewModel.stop()
                             isPlayerDismissed = true
                         })
                     }

--- a/readeck/UI/SpeechPlayer/GlobalPlayerContainerView.swift
+++ b/readeck/UI/SpeechPlayer/GlobalPlayerContainerView.swift
@@ -23,6 +23,9 @@ struct GlobalPlayerContainerView<Content: View>: View {
                     MiniPlayerView(viewModel: viewModel, onTap: {
                         isPlayerSheetPresented = true
                     }, onClose: {
+                        // Closing the player ends playback; hiding it while the
+                        // voice keeps reading leaves no way to stop it.
+                        viewModel.stop()
                         isPlayerDismissed = true
                     })
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/readeck/UI/Utils/SpeechQueue.swift
+++ b/readeck/UI/Utils/SpeechQueue.swift
@@ -52,6 +52,9 @@ final class SpeechQueue {
     private let logger = Logger.general
     private var queue: [SpeechQueueItem] = []
     private var isProcessing = false
+    /// Set when the item at index 0 has been read to the end but is kept around
+    /// for replay. See `dropCompletedItem()`.
+    private var didFinishCurrentItem = false
     private let ttsManager: TTSManager
     private let queueKey = "tts_queue"
     private var lastSaveTime: Date = .distantPast
@@ -116,6 +119,7 @@ final class SpeechQueue {
 
     func enqueue(_ item: SpeechQueueItem) {
         dispatchPrecondition(condition: .onQueue(.main))
+        dropCompletedItem()
         queue.append(item)
         updatePublishedProperties()
         saveQueue()
@@ -124,10 +128,21 @@ final class SpeechQueue {
 
     func enqueue(contentsOf items: [SpeechQueueItem]) {
         dispatchPrecondition(condition: .onQueue(.main))
+        dropCompletedItem()
         queue.append(contentsOf: items)
         updatePublishedProperties()
         saveQueue()
         processQueue()
+    }
+
+    /// The article that just finished stays in the queue so the player keeps
+    /// showing it and it can be replayed. As soon as something new is queued it
+    /// has to go, otherwise `processQueue()` replays it instead of playing the
+    /// article the user just added.
+    private func dropCompletedItem() {
+        guard didFinishCurrentItem, !queue.isEmpty else { return }
+        queue.removeFirst()
+        didFinishCurrentItem = false
     }
 
     func stop() {
@@ -160,6 +175,7 @@ final class SpeechQueue {
         dispatchPrecondition(condition: .onQueue(.main))
         logger.debug("SpeechQueue clear() called")
         queue.removeAll()
+        didFinishCurrentItem = false
         updatePublishedProperties()
         saveQueue()
         ttsManager.stop()
@@ -175,6 +191,7 @@ final class SpeechQueue {
     private func processQueue() {
         guard !isProcessing, !queue.isEmpty else { return }
         isProcessing = true
+        didFinishCurrentItem = false
         let next = queue[0]
         updatePublishedProperties()
         saveQueue()
@@ -209,6 +226,7 @@ final class SpeechQueue {
             // Last item — keep it visible, reset position for replay
             if !queue.isEmpty {
                 queue[0].lastCharacterIndex = 0
+                didFinishCurrentItem = true
             }
             updatePublishedProperties()
             saveQueue()
@@ -219,6 +237,7 @@ final class SpeechQueue {
 
     func insertAfterCurrent(_ item: SpeechQueueItem) {
         dispatchPrecondition(condition: .onQueue(.main))
+        dropCompletedItem()
         if queue.isEmpty {
             enqueue(item)
         } else {
@@ -249,6 +268,7 @@ final class SpeechQueue {
         if removingCurrent {
             ttsManager.stop()
             isProcessing = false
+            didFinishCurrentItem = false
             processQueue()
         }
     }
@@ -259,6 +279,7 @@ final class SpeechQueue {
         queue.insert(item, at: 0)
         ttsManager.stop()
         isProcessing = false
+        didFinishCurrentItem = false
         updatePublishedProperties()
         saveQueue()
         processQueue()
@@ -269,6 +290,7 @@ final class SpeechQueue {
         ttsManager.stop()
         queue.removeFirst()
         isProcessing = false
+        didFinishCurrentItem = false
         updatePublishedProperties()
         saveQueue()
         processQueue()

--- a/readeckTests/Speech/SpeechQueueTests.swift
+++ b/readeckTests/Speech/SpeechQueueTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import readeck
+
+/// Exercises the queue transitions through the shared TTSManager callbacks,
+/// which is how the real player drives them.
+@Suite("SpeechQueue Tests", .serialized)
+@MainActor
+struct SpeechQueueTests {
+
+    private func makeItem(id: String) -> SpeechQueueItem {
+        SpeechQueueItem(
+            id: id,
+            title: "Article \(id)",
+            content: "Content of article \(id)",
+            url: "https://example.com/\(id)",
+            labels: nil,
+            imageUrl: nil,
+            language: "en",
+            lastCharacterIndex: 0,
+            totalCharacters: 20
+        )
+    }
+
+    /// Stands in for the synthesizer reporting the current utterance as done.
+    private func finishCurrentUtterance() {
+        TTSManager.shared.onUtteranceFinished?()
+    }
+
+    /// Stands in for a cancel, which the synthesizer also emits when `speak`
+    /// interrupts itself for a seek or a rate change.
+    private func cancelCurrentUtterance() {
+        TTSManager.shared.onUtteranceCancelled?()
+    }
+
+    @Test("A second article is appended while the first one plays")
+    func secondArticleIsQueued() {
+        let queue = SpeechQueue.shared
+        queue.clear()
+
+        queue.enqueue(makeItem(id: "A"))
+        queue.enqueue(makeItem(id: "B"))
+
+        #expect(queue.queueItems.map(\.id) == ["A", "B"])
+        #expect(queue.currentItem?.id == "A")
+
+        queue.clear()
+    }
+
+    @Test("A finished article is dropped so the next one can play")
+    func finishedArticleDoesNotBlockTheQueue() {
+        let queue = SpeechQueue.shared
+        queue.clear()
+        queue.enqueue(makeItem(id: "A"))
+
+        finishCurrentUtterance()
+        queue.enqueue(makeItem(id: "B"))
+
+        // A already played to the end. Adding B must not put it behind a
+        // finished item that gets replayed instead.
+        #expect(queue.currentItem?.id == "B")
+
+        queue.clear()
+    }
+
+    @Test("A finished article gives way to one queued as next")
+    func finishedArticleGivesWayToListenNext() {
+        let queue = SpeechQueue.shared
+        queue.clear()
+        queue.enqueue(makeItem(id: "A"))
+
+        finishCurrentUtterance()
+        queue.insertAfterCurrent(makeItem(id: "B"))
+
+        #expect(queue.currentItem?.id == "B")
+
+        queue.clear()
+    }
+
+    @Test("A still-playing article keeps its place when another is queued next")
+    func playingArticleKeepsItsPlace() {
+        let queue = SpeechQueue.shared
+        queue.clear()
+        queue.enqueue(makeItem(id: "A"))
+
+        queue.insertAfterCurrent(makeItem(id: "B"))
+
+        #expect(queue.queueItems.map(\.id) == ["A", "B"])
+        #expect(queue.currentItem?.id == "A")
+
+        queue.clear()
+    }
+
+    @Test("A seek does not make the queue restart the article")
+    func cancelFromSeekKeepsTheItemPlaying() {
+        let queue = SpeechQueue.shared
+        queue.clear()
+        queue.enqueue(makeItem(id: "A"))
+
+        // A seek or rate change stops the current utterance and starts a new
+        // one; the cancel callback must not mark the queue as idle.
+        cancelCurrentUtterance()
+        queue.enqueue(makeItem(id: "B"))
+
+        #expect(queue.queueItems.map(\.id) == ["A", "B"])
+        #expect(queue.currentItem?.id == "A")
+
+        queue.clear()
+    }
+}


### PR DESCRIPTION
Stacked on #111 — merge that one first.

A finished article stays at index 0 so the player can still show and replay it. Anything queued afterwards landed behind it, so `processQueue()` replayed the finished article instead of playing the new one. It now gives way as soon as something new is queued.

The mini player's X also only hid the player while the voice kept reading. It now ends playback.

Found via a failing test (`SpeechQueueTests`), which drives the queue through the real TTSManager callbacks. Four more tests cover the opposite direction: a still-playing article keeps its place, and a seek must not restart it.