### PR TITLE
Replace the share extension's open-in-app button with a toggle

### DIFF
--- a/URLShare/ShareBookmarkView.swift
+++ b/URLShare/ShareBookmarkView.swift
@@ -36,6 +36,7 @@ struct ShareBookmarkView: View {
                             titleSection
                                 .id(AddBookmarkFieldFocus.title)
                             sendPageContentSection
+                            openAfterSaveSection
                             statusSection
                             Spacer(minLength: 100) // Space for button
                         }
@@ -51,11 +52,7 @@ struct ShareBookmarkView: View {
                     }
                 }
 
-                if viewModel.savedBookmarkId != nil {
-                    openInAppButtonSection
-                } else {
-                    saveButtonSection
-                }
+                saveButtonSection
             }
         }
         .background(Color(.systemGroupedBackground))
@@ -199,6 +196,25 @@ struct ShareBookmarkView: View {
     }
 
     @ViewBuilder
+    private var openAfterSaveSection: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Open after save")
+                    .font(.system(size: 15, weight: .medium))
+                Text("Jump straight into the article in Readeck")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Toggle("", isOn: $viewModel.openAfterSave)
+                .toggleStyle(.switch)
+                .labelsHidden()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 20)
+    }
+
+    @ViewBuilder
     private var tagManagementSection: some View {
         CoreDataTagManagementView(
             selectedLabels: viewModel.selectedLabels,
@@ -260,22 +276,6 @@ struct ShareBookmarkView: View {
         .padding(.top, 16)
         .padding(.bottom, 32)
         .disabled(viewModel.isSaving)
-    }
-
-    @ViewBuilder
-    private var openInAppButtonSection: some View {
-        Button(action: { viewModel.openInApp() }) {
-            Label("Open in Readeck", systemImage: "arrow.up.forward.app")
-                .font(.system(size: 17, weight: .semibold))
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.accentColor)
-                .foregroundColor(.white)
-                .cornerRadius(16)
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 16)
-        .padding(.bottom, 32)
     }
 
     // MARK: - Helper Functions

--- a/URLShare/ShareBookmarkViewModel.swift
+++ b/URLShare/ShareBookmarkViewModel.swift
@@ -16,10 +16,14 @@ final class ShareBookmarkViewModel: ObservableObject {
     @Published var sessionExpired = false
     @Published var pageHTML: String?
     @Published var includeHTML = false
-    /// Set once the bookmark is saved online and the server returned its id. Drives
-    /// the "Open in Readeck" button; nil after a local save or an older server that
-    /// doesn't return the id.
+    /// Set once the bookmark is saved online and the server returned its id. Needed to
+    /// deep-link into the app; nil after a local save or an older server that doesn't
+    /// return the id.
     @Published var savedBookmarkId: String?
+    /// When on, a successful online save deep-links into the app instead of just
+    /// closing the sheet. Deliberately not remembered: saving and moving on is the
+    /// common case, so opening the app stays an explicit per-share choice.
+    @Published var openAfterSave = false
     let tagSortOrder: TagSortOrder
     let extensionContext: NSExtensionContext?
     /// A view from the hosting controller, used as the entry point into the responder
@@ -145,9 +149,13 @@ final class ShareBookmarkViewModel: ObservableObject {
                     if !error {
                         self.savedBookmarkId = bookmarkId
                         self.logger.debug("Bookmark saved successfully, id available: \(bookmarkId != nil)")
-                        // When we have an id we show an "Open in Readeck" button and give
-                        // the user time to tap it before auto-closing; otherwise close quickly.
-                        self.scheduleAutoClose(after: bookmarkId != nil ? 6.0 : 0.5)
+                        if self.openAfterSave, bookmarkId != nil {
+                            self.openInApp()
+                        } else {
+                            // Saving and getting out of the way is the common case, so
+                            // close as soon as the success state has been shown.
+                            self.scheduleAutoClose(after: 0.5)
+                        }
                     } else {
                         self.logger.error("Failed to save bookmark via API: \(message)")
                     }


### PR DESCRIPTION
The "Open in Readeck" button from #68 kept the share sheet open for six seconds so it could be tapped. A TestFlight tester reported that when they just wanted to save, they had to swipe away both the Readeck sheet and the Apple one.

Now an "Open after save" toggle sits next to "Send page content". Off by default and not remembered, so saving auto-closes after 0.5s again and opening the article is an explicit per-share choice without the wait.