### PR TITLE
feat(theme): OLED pure-black theme, and reader themes across the whole reader

### DIFF
--- a/readeck/Domain/Model/Theme.swift
+++ b/readeck/Domain/Model/Theme.swift
@@ -12,12 +12,14 @@ enum Theme: String, CaseIterable {
     case system
     case light
     case dark
+    case oled
 
     var displayName: String {
         switch self {
         case .system: return "System"
         case .light: return "Light"
         case .dark: return "Dark"
+        case .oled: return "OLED"
         }
     }
 
@@ -25,7 +27,11 @@ enum Theme: String, CaseIterable {
         switch self {
         case .system: return nil
         case .light: return .light
-        case .dark: return .dark
+        case .dark, .oled: return .dark
         }
     }
+
+    /// True when the theme forces pure-black (#000000) surfaces instead of the
+    /// system's elevated dark grays. Used to tint app chrome and scroll backgrounds.
+    var isOLED: Bool { self == .oled }
 }

--- a/readeck/UI/BookmarkDetail/AnnotationsListView.swift
+++ b/readeck/UI/BookmarkDetail/AnnotationsListView.swift
@@ -4,6 +4,7 @@ struct AnnotationsListView: View {
     let bookmarkId: String
     @State private var viewModel = AnnotationsListViewModel()
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appSettings: AppSettings
     var onAnnotationTap: ((String) -> Void)?
 
     enum ViewState {
@@ -81,6 +82,7 @@ struct AnnotationsListView: View {
                     EmptyView()
                 }
             }
+            .oledScrollBackground(appSettings.theme.isOLED)
             .navigationTitle("Annotations")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -129,4 +131,5 @@ struct AnnotationsListView: View {
     NavigationStack {
         AnnotationsListView(bookmarkId: "123")
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderLegacyView.swift
@@ -32,6 +32,7 @@ struct ArticleReaderLegacyView: View {
 
     @EnvironmentObject private var appSettings: AppSettings
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     private let headerHeight: Double = 360
 
@@ -44,7 +45,7 @@ struct ArticleReaderLegacyView: View {
     var body: some View {
         mainContent
             .frame(maxWidth: .infinity)
-            .background(nativeBackgroundColor)
+            .background(readerTheme.backgroundColor.ignoresSafeArea())
     }
 
     private var mainContent: some View {
@@ -204,7 +205,17 @@ struct ArticleReaderLegacyView: View {
                 }
             }
         }
+        // Everything inside the reader adopts the theme's brightness so system-tinted
+        // elements stay legible on a light theme while the app runs in dark mode, and
+        // vice versa. Applied here so the presented sheets keep the app appearance.
+        .environment(\.colorScheme, readerTheme.colorScheme)
         .navigationBarTitleDisplayMode(.inline)
+        // Local to this screen on purpose: OLEDTheme.swift owns the global
+        // UINavigationBar appearance proxy, and a second writer would leave the
+        // bookmark list tinted after leaving the reader.
+        .toolbarBackground(readerTheme.backgroundColor, for: .navigationBar)
+        .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+        .toolbarColorScheme(readerTheme.colorScheme, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Menu {
@@ -388,22 +399,10 @@ struct ArticleReaderLegacyView: View {
         .padding(.horizontal)
     }
 
+    // The page background now carries the theme, so the card needs its own tint to
+    // stay visible instead of a translucent copy of the same color.
     private var summaryCardBackgroundColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system:
-            return Color(.secondarySystemBackground)
-        case .custom:
-            if let hex = viewModel.settings?.customBackgroundColor {
-                return Color(hex: hex).opacity(0.85)
-            }
-            return Color(.secondarySystemBackground)
-        default:
-            if let bg = theme.backgroundColor {
-                return bg.opacity(0.85)
-            }
-            return Color(.secondarySystemBackground)
-        }
+        readerTheme.surfaceColor
     }
 
     @ViewBuilder
@@ -521,36 +520,17 @@ struct ArticleReaderLegacyView: View {
 
     // MARK: - Color Theme Helpers
 
-    private var nativeBackgroundColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system: return Color(.systemBackground)
-        case .custom:
-            if let hex = viewModel.settings?.customBackgroundColor {
-                return Color(hex: hex)
-            }
-            return Color(.systemBackground)
-        default:
-            return theme.backgroundColor ?? Color(.systemBackground)
-        }
+    /// Single source of truth for the reader's colors, shared with the web view.
+    private var readerTheme: ReaderTheme {
+        ReaderTheme.resolve(settings: viewModel.settings, isDarkMode: colorScheme == .dark)
     }
 
     private var nativeTextColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system: return .primary
-        case .custom:
-            if let hex = viewModel.settings?.customTextColor {
-                return Color(hex: hex)
-            }
-            return .primary
-        default:
-            return theme.textColor ?? .primary
-        }
+        readerTheme.textColor
     }
 
     private var nativeSecondaryTextColor: Color {
-        nativeTextColor.opacity(0.6)
+        readerTheme.secondaryTextColor
     }
 
     @ViewBuilder

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -26,6 +26,7 @@ struct ArticleReaderView: View {
 
     @EnvironmentObject private var appSettings: AppSettings
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     private let headerHeight: Double = 360
 
@@ -37,7 +38,7 @@ struct ArticleReaderView: View {
 
     var body: some View {
         mainView
-            .background(nativeBackgroundColor)
+            .background(readerTheme.backgroundColor.ignoresSafeArea())
     }
 
     private var mainView: some View {
@@ -47,6 +48,12 @@ struct ArticleReaderView: View {
                 toolbarContent
             }
             .toolbar(isToolbarVisible ? .visible : .hidden, for: .navigationBar)
+            // Local to this screen on purpose: OLEDTheme.swift owns the global
+            // UINavigationBar appearance proxy, and a second writer would leave the
+            // bookmark list tinted after leaving the reader.
+            .toolbarBackground(readerTheme.backgroundColor, for: .navigationBar)
+            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+            .toolbarColorScheme(readerTheme.colorScheme, for: .navigationBar)
             .animation(.easeInOut(duration: 0.35), value: isToolbarVisible)
             .sheet(isPresented: $showingFontSettings) {
                 fontSettingsSheet
@@ -137,6 +144,11 @@ struct ArticleReaderView: View {
                 }
                 .animation(.spring(response: 0.6, dampingFraction: 0.8), value: readingProgress >= 0.9)
         }
+        // Everything inside the reader adopts the theme's brightness so system-tinted
+        // elements (progress bar, dividers, glass buttons, loading labels) stay legible
+        // on a light theme while the app runs in dark mode, and vice versa. Applied
+        // here and not on `mainView` so the presented sheets keep the app appearance.
+        .environment(\.colorScheme, readerTheme.colorScheme)
     }
 
     private var floatingActionButtons: some View {
@@ -368,22 +380,10 @@ struct ArticleReaderView: View {
         .padding(.horizontal)
     }
 
+    // The page background now carries the theme, so the card needs its own tint to
+    // stay visible instead of a translucent copy of the same color.
     private var summaryCardBackgroundColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system:
-            return Color(.secondarySystemBackground)
-        case .custom:
-            if let hex = viewModel.settings?.customBackgroundColor {
-                return Color(hex: hex).opacity(0.85)
-            }
-            return Color(.secondarySystemBackground)
-        default:
-            if let bg = theme.backgroundColor {
-                return bg.opacity(0.85)
-            }
-            return Color(.secondarySystemBackground)
-        }
+        readerTheme.surfaceColor
     }
 
     private var metaInfoSection: some View {
@@ -465,36 +465,17 @@ struct ArticleReaderView: View {
 
     // MARK: - Color Theme Helpers
 
-    private var nativeBackgroundColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system: return Color(.systemBackground)
-        case .custom:
-            if let hex = viewModel.settings?.customBackgroundColor {
-                return Color(hex: hex)
-            }
-            return Color(.systemBackground)
-        default:
-            return theme.backgroundColor ?? Color(.systemBackground)
-        }
+    /// Single source of truth for the reader's colors, shared with the web view.
+    private var readerTheme: ReaderTheme {
+        ReaderTheme.resolve(settings: viewModel.settings, isDarkMode: colorScheme == .dark)
     }
 
     private var nativeTextColor: Color {
-        let theme = viewModel.settings?.readerColorTheme ?? .system
-        switch theme {
-        case .system: return .primary
-        case .custom:
-            if let hex = viewModel.settings?.customTextColor {
-                return Color(hex: hex)
-            }
-            return .primary
-        default:
-            return theme.textColor ?? .primary
-        }
+        readerTheme.textColor
     }
 
     private var nativeSecondaryTextColor: Color {
-        nativeTextColor.opacity(0.6)
+        readerTheme.secondaryTextColor
     }
 
     @ViewBuilder

--- a/readeck/UI/Bookmarks/BookmarkCardView.swift
+++ b/readeck/UI/Bookmarks/BookmarkCardView.swift
@@ -45,6 +45,11 @@ struct BookmarkCardView: View {
         self.onPlayNext = onPlayNext
     }
 
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             Group {
@@ -236,7 +241,7 @@ struct BookmarkCardView: View {
             }
         }
         .padding(12)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -319,7 +324,7 @@ struct BookmarkCardView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 12)
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
         .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
@@ -405,7 +410,7 @@ struct BookmarkCardView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 12)
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.08), radius: 6, x: 0, y: 3)
     }

--- a/readeck/UI/Bookmarks/BookmarksView.swift
+++ b/readeck/UI/Bookmarks/BookmarksView.swift
@@ -76,6 +76,11 @@ struct BookmarksView: View {
         }
     }
 
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
@@ -207,7 +212,7 @@ struct BookmarksView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
     }
 
     @ViewBuilder
@@ -377,7 +382,7 @@ struct BookmarksView: View {
                     trailing: 16
                 ))
                 .listRowSeparator(.hidden)
-                .listRowBackground(Color(R.color.bookmark_list_bg))
+                .listRowBackground(listBackground)
             }
 
             // Show loading indicator for pagination
@@ -388,12 +393,12 @@ struct BookmarksView: View {
                         .scaleEffect(0.8)
                     Spacer()
                 }
-                .listRowBackground(Color(R.color.bookmark_list_bg))
+                .listRowBackground(listBackground)
                 .listRowSeparator(.hidden)
             }
         }
         .listStyle(.plain)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .scrollContentBackground(.hidden)
         .refreshable {
             await viewModel.refreshBookmarks()
@@ -424,7 +429,7 @@ struct BookmarksView: View {
                     )
                 )
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .refreshable {
             await viewModel.refreshBookmarks()
         }

--- a/readeck/UI/Components/NativeWebView.swift
+++ b/readeck/UI/Components/NativeWebView.swift
@@ -20,9 +20,17 @@ struct NativeWebView: View {
     @State private var scrollPollingTask: Task<Void, Never>?
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Effective reader colors, shared with the surrounding SwiftUI chrome.
+    private var theme: ReaderTheme {
+        ReaderTheme.resolve(settings: settings, isDarkMode: colorScheme == .dark)
+    }
+
     var body: some View {
         WebKit.WebView(webPage)
             .scrollDisabled(true) // Disable internal scrolling
+            // Keeps the themed color behind the page while it is still loading, so
+            // no white or gray sliver flashes before the CSS applies.
+            .background(theme.backgroundColor)
             .onAppear {
                 loadStyledContent()
                 setupAnnotationMessageHandler()
@@ -196,29 +204,12 @@ struct NativeWebView: View {
         let lineHeightValue = settings.lineHeight ?? 1.4
         let selectedFontFamily = settings.fontFamily ?? .serif
 
-        // Resolve color theme
-        let colorTheme = settings.readerColorTheme ?? .system
-        let resolvedBgColor: String
-        let resolvedTextColor: String
-        let resolvedHeadingColor: String
-        let themeIsDark: Bool
-        switch colorTheme {
-        case .system:
-            resolvedBgColor = isDarkMode ? "#000000" : "#ffffff"
-            resolvedTextColor = isDarkMode ? "#ffffff" : "#1a1a1a"
-            resolvedHeadingColor = isDarkMode ? "#ffffff" : "#000000"
-            themeIsDark = isDarkMode
-        case .custom:
-            resolvedBgColor = settings.customBackgroundColor ?? (isDarkMode ? "#000000" : "#ffffff")
-            resolvedTextColor = settings.customTextColor ?? (isDarkMode ? "#ffffff" : "#1a1a1a")
-            resolvedHeadingColor = resolvedTextColor
-            themeIsDark = isDarkMode
-        default:
-            resolvedBgColor = colorTheme.backgroundHex ?? (isDarkMode ? "#000000" : "#ffffff")
-            resolvedTextColor = colorTheme.textHex ?? (isDarkMode ? "#ffffff" : "#1a1a1a")
-            resolvedHeadingColor = resolvedTextColor
-            themeIsDark = colorTheme.isDark
-        }
+        // Resolve color theme (same source the SwiftUI chrome uses)
+        let readerTheme = theme
+        let resolvedBgColor = readerTheme.backgroundHex
+        let resolvedTextColor = readerTheme.textHex
+        let resolvedHeadingColor = readerTheme.headingHex
+        let themeIsDark = readerTheme.isDark
         let fontCSS = ReaderFontCSSBuilder.build(fontFamily: selectedFontFamily)
         let codeFontFamily = selectedFontFamily == .monospace
             ? "var(--font-family)"
@@ -242,6 +233,7 @@ struct NativeWebView: View {
                 html {
                     overflow-x: hidden;
                     width: 100%;
+                    background-color: \(resolvedBgColor);
                 }
 
                 body {

--- a/readeck/UI/Components/SkeletonLoadingView.swift
+++ b/readeck/UI/Components/SkeletonLoadingView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 struct SkeletonLoadingView: View {
     let layout: CardLayoutStyle
     @State private var animateGradient = false
+    @EnvironmentObject private var appSettings: AppSettings
+
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
 
     var body: some View {
         LazyVStack(spacing: layout == .compact ? 8 : 12) {
@@ -72,7 +78,7 @@ struct SkeletonLoadingView: View {
             }
         }
         .padding(12)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -110,7 +116,7 @@ struct SkeletonLoadingView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 12)
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
         .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
@@ -150,7 +156,7 @@ struct SkeletonLoadingView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 12)
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: Color.black.opacity(0.08), radius: 6, x: 0, y: 3)
     }
@@ -173,4 +179,5 @@ struct SkeletonLoadingView: View {
         SkeletonLoadingView(layout: .magazine)
             .padding()
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/Components/WebView.swift
+++ b/readeck/UI/Components/WebView.swift
@@ -22,8 +22,11 @@ struct WebView: UIViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.scrollView.isScrollEnabled = false
+        // Transparent so the themed SwiftUI background shows through while the
+        // article is still loading, instead of a white or gray flash.
         webView.isOpaque = false
         webView.backgroundColor = UIColor.clear
+        webView.scrollView.backgroundColor = UIColor.clear
 
         // Allow text selection and copying
         webView.allowsBackForwardNavigationGestures = false
@@ -68,29 +71,13 @@ struct WebView: UIViewRepresentable {
         guard context.coordinator.lastRenderKey != renderKey else { return }
         context.coordinator.lastRenderKey = renderKey
 
-        // Resolve color theme
+        // Resolve color theme (same source the SwiftUI chrome uses)
         let colorTheme = settings.readerColorTheme ?? .system
-        let resolvedBgColor: String
-        let resolvedTextColor: String
-        let resolvedHeadingColor: String
-        let themeIsDark: Bool
-        switch colorTheme {
-        case .system:
-            resolvedBgColor = isDarkMode ? "#000000" : "#ffffff"
-            resolvedTextColor = isDarkMode ? "#ffffff" : "#1a1a1a"
-            resolvedHeadingColor = isDarkMode ? "#ffffff" : "#000000"
-            themeIsDark = isDarkMode
-        case .custom:
-            resolvedBgColor = settings.customBackgroundColor ?? (isDarkMode ? "#000000" : "#ffffff")
-            resolvedTextColor = settings.customTextColor ?? (isDarkMode ? "#ffffff" : "#1a1a1a")
-            resolvedHeadingColor = resolvedTextColor
-            themeIsDark = isDarkMode
-        default:
-            resolvedBgColor = colorTheme.backgroundHex ?? (isDarkMode ? "#000000" : "#ffffff")
-            resolvedTextColor = colorTheme.textHex ?? (isDarkMode ? "#ffffff" : "#1a1a1a")
-            resolvedHeadingColor = resolvedTextColor
-            themeIsDark = colorTheme.isDark
-        }
+        let readerTheme = ReaderTheme.resolve(settings: settings, isDarkMode: isDarkMode)
+        let resolvedBgColor = readerTheme.backgroundHex
+        let resolvedTextColor = readerTheme.textHex
+        let resolvedHeadingColor = readerTheme.headingHex
+        let themeIsDark = readerTheme.isDark
         let fontCSS = ReaderFontCSSBuilder.build(fontFamily: selectedFontFamily)
         let codeFontFamily = selectedFontFamily == .monospace
             ? "var(--font-family)"
@@ -136,6 +123,10 @@ struct WebView: UIViewRepresentable {
                     /* Font Settings from Settings */
                     --base-font-size: \(fontSize)px;
                     --font-family: \(fontCSS.fontStackCSS);
+                }
+
+                html {
+                    background-color: var(--background-color);
                 }
 
                 body {

--- a/readeck/UI/Labels/LabelsView.swift
+++ b/readeck/UI/Labels/LabelsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LabelsView: View {
     @State private var viewModel = LabelsViewModel()
+    @EnvironmentObject private var appSettings: AppSettings
     @Binding var selectedTag: BookmarkLabel?
 
     init(viewModel: LabelsViewModel = LabelsViewModel(), selectedTag: Binding<BookmarkLabel?>) {
@@ -38,6 +39,7 @@ struct LabelsView: View {
                         }
                     }
                 }
+                .oledScrollBackground(appSettings.theme.isOLED)
             }
         }
         .onAppear {

--- a/readeck/UI/Menu/PadSidebarView.swift
+++ b/readeck/UI/Menu/PadSidebarView.swift
@@ -19,6 +19,11 @@ struct PadSidebarView: View {
 
     private let sidebarTabs: [SidebarTab] = [.search, .all, .unread, .favorite, .archived, .article, .videos, .pictures, .tags]
 
+    /// Sidebar surface color; pure black while the OLED theme is active.
+    private var sidebarBackground: Color {
+        Color(R.color.menu_sidebar_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             List {
@@ -33,11 +38,11 @@ struct PadSidebarView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                     }
-                    .listRowBackground(selectedTab == tab ? Color.accentColor.opacity(0.15) : Color(R.color.menu_sidebar_bg))
+                    .listRowBackground(selectedTab == tab ? Color.accentColor.opacity(0.15) : sidebarBackground)
 
                     if tab == .archived {
                         Spacer()
-                            .listRowBackground(Color(R.color.menu_sidebar_bg))
+                            .listRowBackground(sidebarBackground)
                     }
                 }
 
@@ -55,8 +60,8 @@ struct PadSidebarView: View {
                     }
                 }
             }
-            .listRowBackground(Color(R.color.menu_sidebar_bg))
-            .background(Color(R.color.menu_sidebar_bg))
+            .listRowBackground(sidebarBackground)
+            .background(sidebarBackground)
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
             .safeAreaInset(edge: .bottom, alignment: .center) {
@@ -80,10 +85,10 @@ struct PadSidebarView: View {
                             .padding(.vertical, 12)
                             .contentShape(Rectangle())
                     }
-                    .listRowBackground(selectedTab == .settings ? Color.accentColor.opacity(0.15) : Color(R.color.menu_sidebar_bg))
+                    .listRowBackground(selectedTab == .settings ? Color.accentColor.opacity(0.15) : sidebarBackground)
                 }
                 .padding(.horizontal, 12)
-                .background(Color(R.color.menu_sidebar_bg))
+                .background(sidebarBackground)
             }
         } content: {
             GlobalPlayerContainerView(viewModel: speechPlayerViewModel, isPlayerDismissed: $isPlayerDismissed) {
@@ -140,7 +145,7 @@ struct PadSidebarView: View {
                 Text("").foregroundColor(.gray)
             }
         }
-        .background(Color(R.color.menu_sidebar_bg))
+        .background(sidebarBackground)
         .task {
             await speechPlayerViewModel.setup()
         }

--- a/readeck/UI/Menu/PhoneTabView.swift
+++ b/readeck/UI/Menu/PhoneTabView.swift
@@ -38,6 +38,11 @@ struct PhoneTabView: View {
         offlineBookmarksViewModel.state.localBookmarkCount > 0 ? offlineBookmarksViewModel.state.localBookmarkCount : 0
     }
 
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     var body: some View {
         Group {
             if #available(iOS 26.1, *) {
@@ -214,10 +219,10 @@ struct PhoneTabView: View {
                     trailing: 16
                 ))
                 .listRowSeparator(.hidden)
-                .listRowBackground(Color(R.color.bookmark_list_bg))
+                .listRowBackground(listBackground)
             }
             .scrollContentBackground(.hidden)
-            .background(Color(R.color.bookmark_list_bg))
+            .background(listBackground)
             .listStyle(.plain)
         } else if searchViewModel.searchQuery.isEmpty == false {
             ContentUnavailableView("No results", systemImage: "magnifyingglass", description: Text("No bookmarks found."))
@@ -236,7 +241,7 @@ struct PhoneTabView: View {
                 } label: {
                     Label(tab.label, systemImage: tab.systemImage)
                 }
-                .listRowBackground(Color(R.color.bookmark_list_bg))
+                .listRowBackground(listBackground)
             }
 
             if case .idle = offlineBookmarksViewModel.state {
@@ -255,7 +260,7 @@ struct PhoneTabView: View {
         }
         .navigationTitle("More")
         .scrollContentBackground(.hidden)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
     }
 
     @ViewBuilder

--- a/readeck/UI/Search/SearchBookmarksView.swift
+++ b/readeck/UI/Search/SearchBookmarksView.swift
@@ -10,6 +10,11 @@ struct SearchBookmarksView: View {
     @State private var cardLayoutStyle: CardLayoutStyle = .magazine
     @EnvironmentObject private var appSettings: AppSettings
 
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -81,10 +86,10 @@ struct SearchBookmarksView: View {
                         trailing: 16
                     ))
                     .listRowSeparator(.hidden)
-                    .listRowBackground(Color(R.color.bookmark_list_bg))
+                    .listRowBackground(listBackground)
                 }
                 .listStyle(.plain)
-                .background(Color(R.color.bookmark_list_bg))
+                .background(listBackground)
                 .scrollContentBackground(.hidden)
                 .simultaneousGesture(
                     DragGesture()
@@ -98,7 +103,7 @@ struct SearchBookmarksView: View {
             }
             Spacer()
         }
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .navigationTitle("Search")
         .navigationDestination(
             item: Binding<String?>(

--- a/readeck/UI/Settings/CachedArticlesPreviewView.swift
+++ b/readeck/UI/Settings/CachedArticlesPreviewView.swift
@@ -14,6 +14,11 @@ struct CachedArticlesPreviewView: View {
     @State private var selectedBookmarkId: String?
     @EnvironmentObject private var appSettings: AppSettings
 
+    /// List surface color; pure black while the OLED theme is active.
+    private var listBackground: Color {
+        Color(R.color.bookmark_list_bg).oledBlack(appSettings.theme.isOLED)
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -69,7 +74,7 @@ struct CachedArticlesPreviewView: View {
                         trailing: 16
                     ))
                     .listRowSeparator(.hidden)
-                    .listRowBackground(Color(R.color.bookmark_list_bg))
+                    .listRowBackground(listBackground)
                 }
             } header: {
                 HStack {
@@ -89,7 +94,7 @@ struct CachedArticlesPreviewView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
         .scrollContentBackground(.hidden)
         .refreshable {
             await viewModel.refreshList()
@@ -114,7 +119,7 @@ struct CachedArticlesPreviewView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
     }
 
     @ViewBuilder
@@ -145,7 +150,7 @@ struct CachedArticlesPreviewView: View {
         }
         .padding(.horizontal, 40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
     }
 
     @ViewBuilder
@@ -185,7 +190,7 @@ struct CachedArticlesPreviewView: View {
             .padding(.top, 8)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(R.color.bookmark_list_bg))
+        .background(listBackground)
     }
 }
 

--- a/readeck/UI/Settings/CardLayoutSelectionView.swift
+++ b/readeck/UI/Settings/CardLayoutSelectionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CardLayoutSelectionView: View {
     @Binding var selectedCardLayout: CardLayoutStyle
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appSettings: AppSettings
 
     let onSave: () -> Void
 
@@ -29,6 +30,7 @@ struct CardLayoutSelectionView: View {
             }
         }
         .listStyle(.plain)
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle("Card Layout")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -169,4 +171,5 @@ struct CardLayoutPreview: View {
             selectedCardLayout: .constant(.magazine)
         )            {}
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/Settings/CustomCSSHelpView.swift
+++ b/readeck/UI/Settings/CustomCSSHelpView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct CustomCSSHelpView: View {
     @Binding var customCSS: String
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appSettings: AppSettings
 
     var body: some View {
         NavigationStack {
@@ -23,6 +24,7 @@ struct CustomCSSHelpView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .oledScrollBackground(appSettings.theme.isOLED)
             .navigationTitle("css.help.title".localized)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/readeck/UI/Settings/FontSelectionView.swift
+++ b/readeck/UI/Settings/FontSelectionView.swift
@@ -11,6 +11,7 @@ struct FontSelectionView: View {
     @State private var viewModel: FontSettingsViewModel
     @State private var showCSSHelp = false
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appSettings: AppSettings
 
     init(viewModel: FontSettingsViewModel = FontSettingsViewModel()) {
         self.viewModel = viewModel
@@ -35,6 +36,7 @@ struct FontSelectionView: View {
                 customCSSSection
             }
             .listStyle(.insetGrouped)
+            .oledScrollBackground(appSettings.theme.isOLED)
         }
         .navigationTitle("Reader Settings")
         .navigationBarTitleDisplayMode(.inline)
@@ -381,4 +383,5 @@ struct FontSelectionView: View {
             factory: MockUseCaseFactory()
         ))
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/Settings/OfflineReadingDetailView.swift
+++ b/readeck/UI/Settings/OfflineReadingDetailView.swift
@@ -171,6 +171,7 @@ struct OfflineReadingDetailView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle("Offline Reading".localized)
         .navigationBarTitleDisplayMode(.inline)
         .task {

--- a/readeck/UI/Settings/OpenSourceLicensesView.swift
+++ b/readeck/UI/Settings/OpenSourceLicensesView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OpenSourceLicensesView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appSettings: AppSettings
 
     var body: some View {
         NavigationStack {
@@ -97,6 +98,7 @@ struct OpenSourceLicensesView: View {
                     Text("Apple Fonts")
                 }
             }
+            .oledScrollBackground(appSettings.theme.isOLED)
             .navigationTitle("Open Source Licenses")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -132,4 +134,5 @@ struct FontLicenseRow: View {
 
 #Preview {
     OpenSourceLicensesView()
+        .environmentObject(AppSettings())
 }

--- a/readeck/UI/Settings/SettingsContainerView.swift
+++ b/readeck/UI/Settings/SettingsContainerView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SettingsContainerView: View {
     @State private var offlineViewModel = OfflineSettingsViewModel()
     @State private var activeSheet: SettingsSheet?
+    @EnvironmentObject private var appSettings: AppSettings
 
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -98,6 +99,7 @@ struct SettingsContainerView: View {
             appInfoSection
         }
         .listStyle(.insetGrouped)
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.large)
         .task {
@@ -209,4 +211,5 @@ extension View {
     NavigationStack {
         SettingsContainerView()
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/Settings/SwipeActionsSettingsView.swift
+++ b/readeck/UI/Settings/SwipeActionsSettingsView.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 struct SwipeActionsSettingsView: View {
-    @EnvironmentObject var appSettings: AppSettings
+    @EnvironmentObject private var appSettings: AppSettings
     @State private var config: SwipeActionConfig = .default
     @State private var isLoaded = false
 
@@ -65,6 +65,7 @@ struct SwipeActionsSettingsView: View {
 }
 
 struct SwipeActionsDetailView: View {
+    @EnvironmentObject private var appSettings: AppSettings
     @Binding var config: SwipeActionConfig
     let onSave: () -> Void
     @State private var showAddLeading = false
@@ -158,6 +159,7 @@ struct SwipeActionsDetailView: View {
                 .foregroundColor(.red)
             }
         }
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle("Swipe Actions")
         .navigationBarTitleDisplayMode(.inline)
         .environment(\.editMode, .constant(.active))
@@ -199,6 +201,7 @@ struct SwipeActionsDetailView: View {
                     }
                 }
             }
+            .oledScrollBackground(appSettings.theme.isOLED)
             .navigationTitle("Add Action")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/readeck/UI/Settings/TTSLanguageSettingsView.swift
+++ b/readeck/UI/Settings/TTSLanguageSettingsView.swift
@@ -4,6 +4,7 @@ import AVFoundation
 struct TTSLanguageSettingsView: View {
     @AppStorage("tts_preferred_language") private var preferredLanguage = "en-US"
     @ObservedObject private var voiceManager = VoiceManager.shared
+    @EnvironmentObject private var appSettings: AppSettings
 
     private let supportedLanguages: [(code: String, name: String)] = [
         ("de-DE", "Deutsch"),
@@ -60,6 +61,7 @@ struct TTSLanguageSettingsView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle("Language & Voices")
         .onAppear {
             voiceManager.refreshVoices()
@@ -80,4 +82,5 @@ struct TTSLanguageSettingsView: View {
     NavigationStack {
         TTSLanguageSettingsView()
     }
+    .environmentObject(AppSettings())
 }

--- a/readeck/UI/Settings/VoiceListView.swift
+++ b/readeck/UI/Settings/VoiceListView.swift
@@ -6,6 +6,7 @@ struct VoiceListView: View {
     let languageName: String
     @ObservedObject private var voiceManager = VoiceManager.shared
     @State private var previewingVoiceId: String? = nil
+    @EnvironmentObject private var appSettings: AppSettings
 
     private var voicesByQuality: [(quality: String, voices: [AVSpeechSynthesisVoice])] {
         let voices = voiceManager.getAvailableVoices(for: languageCode)
@@ -85,6 +86,7 @@ struct VoiceListView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .oledScrollBackground(appSettings.theme.isOLED)
         .navigationTitle(languageName)
         .onDisappear {
             voiceManager.stopPreview()

--- a/readeck/UI/Utils/OLEDTheme.swift
+++ b/readeck/UI/Utils/OLEDTheme.swift
@@ -1,0 +1,117 @@
+//
+//  OLEDTheme.swift
+//  readeck
+//
+
+import SwiftUI
+import UIKit
+
+/// Forces pure-black app chrome (navigation and tab bars) while the OLED theme is active.
+struct OLEDThemeModifier: ViewModifier {
+    let isActive: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isActive, initial: true) { _, newValue in
+                Self.applyChromeAppearance(black: newValue)
+            }
+    }
+
+    /// Updates the UIKit appearance proxies for navigation and tab bars.
+    @MainActor
+    static func applyChromeAppearance(black: Bool) {
+        let navigationAppearance = UINavigationBarAppearance()
+        let tabAppearance = UITabBarAppearance()
+
+        if black {
+            navigationAppearance.configureWithOpaqueBackground()
+            navigationAppearance.backgroundColor = .black
+            tabAppearance.configureWithOpaqueBackground()
+            tabAppearance.backgroundColor = .black
+        } else {
+            navigationAppearance.configureWithDefaultBackground()
+            tabAppearance.configureWithDefaultBackground()
+        }
+
+        UINavigationBar.appearance().standardAppearance = navigationAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navigationAppearance
+        UITabBar.appearance().standardAppearance = tabAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+
+        // The appearance proxy only affects bars that are created afterwards. The user
+        // switches the theme from the Settings screen, whose navigation bar (and the
+        // surrounding tab bar) already exists and would stay gray until the next app
+        // launch. Push the new appearance onto the bars that are currently on screen.
+        updateVisibleBars(navigationAppearance: navigationAppearance, tabAppearance: tabAppearance)
+    }
+
+    @MainActor
+    private static func updateVisibleBars(
+        navigationAppearance: UINavigationBarAppearance,
+        tabAppearance: UITabBarAppearance
+    ) {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+
+        for window in windows {
+            updateBars(in: window, navigationAppearance: navigationAppearance, tabAppearance: tabAppearance)
+        }
+    }
+
+    @MainActor
+    private static func updateBars(
+        in view: UIView,
+        navigationAppearance: UINavigationBarAppearance,
+        tabAppearance: UITabBarAppearance
+    ) {
+        if let navigationBar = view as? UINavigationBar {
+            navigationBar.standardAppearance = navigationAppearance
+            navigationBar.scrollEdgeAppearance = navigationAppearance
+            navigationBar.setNeedsLayout()
+        }
+
+        if let tabBar = view as? UITabBar {
+            tabBar.standardAppearance = tabAppearance
+            tabBar.scrollEdgeAppearance = tabAppearance
+            tabBar.setNeedsLayout()
+        }
+
+        for subview in view.subviews {
+            updateBars(in: subview, navigationAppearance: navigationAppearance, tabAppearance: tabAppearance)
+        }
+    }
+}
+
+extension View {
+    /// Keeps the app chrome in sync with the OLED theme. Apply once at the app root.
+    func oledTheme(_ isActive: Bool) -> some View {
+        modifier(OLEDThemeModifier(isActive: isActive))
+    }
+
+    /// Replaces the system's elevated scroll background of a `List` or `ScrollView`
+    /// with pure black. SwiftUI ignores the global UIKit table appearance, so this has
+    /// to be applied per screen.
+    ///
+    /// Rows that set their own `listRowBackground` keep it; grouped list cells that rely
+    /// on the system's elevated gray inherit the black row background from here.
+    @ViewBuilder
+    func oledScrollBackground(_ isActive: Bool) -> some View {
+        if isActive {
+            self
+                .scrollContentBackground(.hidden)
+                .listRowBackground(Color.black)
+                .background(Color.black)
+        } else {
+            self
+        }
+    }
+}
+
+extension Color {
+    /// Returns pure black while the OLED theme is active, otherwise the receiver.
+    /// Used for surfaces that carry an explicit background color instead of a system one.
+    func oledBlack(_ isActive: Bool) -> Color {
+        isActive ? .black : self
+    }
+}

--- a/readeck/UI/Utils/ReaderTheme.swift
+++ b/readeck/UI/Utils/ReaderTheme.swift
@@ -1,0 +1,101 @@
+//
+//  ReaderTheme.swift
+//  readeck
+//
+
+import SwiftUI
+
+/// The colors the reader actually paints with, after `ReaderColorTheme.system` has
+/// been resolved against the current appearance and `.custom` against the user's
+/// stored hex values.
+///
+/// Both the SwiftUI chrome (view background, navigation bar, title, meta rows) and
+/// the CSS injected into the web view read from here, so the native frame and the
+/// article content cannot drift apart.
+struct ReaderTheme: Equatable {
+    let backgroundHex: String
+    let textHex: String
+    let headingHex: String
+
+    var backgroundColor: Color { Color(hex: backgroundHex) }
+    var textColor: Color { Color(hex: textHex) }
+    var secondaryTextColor: Color { textColor.opacity(0.6) }
+
+    /// Slightly tinted background for cards that have to lift off the page without
+    /// breaking out of the theme.
+    var surfaceColor: Color {
+        Color(hex: Self.blend(backgroundHex, toward: textHex, amount: 0.08))
+    }
+
+    /// True when the resolved background needs light foreground content. Derived from
+    /// the background's brightness instead of the theme case, so it also covers
+    /// `.system` and user-picked `.custom` colors.
+    var isDark: Bool { Self.brightness(ofHex: backgroundHex) < 0.5 }
+
+    /// Color scheme the reader adopts so system-tinted controls and the navigation
+    /// bar stay legible on the resolved background.
+    var colorScheme: ColorScheme { isDark ? .dark : .light }
+
+    /// Resolves the effective reader colors.
+    /// - Parameter isDarkMode: The appearance the `.system` theme falls back to.
+    static func resolve(settings: Settings?, isDarkMode: Bool) -> Self {
+        let theme = settings?.readerColorTheme ?? .system
+        // Pure black instead of the elevated system gray: the reader should read as
+        // one sheet of paper, and the OLED app theme expects a black reader too.
+        let systemBackground = isDarkMode ? "#000000" : "#ffffff"
+        let systemText = isDarkMode ? "#ffffff" : "#1a1a1a"
+
+        switch theme {
+        case .system:
+            return Self(
+                backgroundHex: systemBackground,
+                textHex: systemText,
+                headingHex: isDarkMode ? "#ffffff" : "#000000"
+            )
+        case .custom:
+            let text = settings?.customTextColor ?? systemText
+            return Self(
+                backgroundHex: settings?.customBackgroundColor ?? systemBackground,
+                textHex: text,
+                headingHex: text
+            )
+        default:
+            let text = theme.textHex ?? systemText
+            return Self(
+                backgroundHex: theme.backgroundHex ?? systemBackground,
+                textHex: text,
+                headingHex: text
+            )
+        }
+    }
+
+    // MARK: - Hex helpers
+
+    private static func components(ofHex hex: String) -> (r: Double, g: Double, b: Double) {
+        let trimmed = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        var value: UInt64 = 0
+        Scanner(string: trimmed).scanHexInt64(&value)
+
+        return (
+            Double((value & 0xFF0000) >> 16) / 255.0,
+            Double((value & 0x00FF00) >> 8) / 255.0,
+            Double(value & 0x0000FF) / 255.0
+        )
+    }
+
+    /// Perceived brightness in the 0...1 range.
+    private static func brightness(ofHex hex: String) -> Double {
+        let rgb = components(ofHex: hex)
+        return 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b
+    }
+
+    private static func blend(_ hex: String, toward other: String, amount: Double) -> String {
+        let base = components(ofHex: hex)
+        let target = components(ofHex: other)
+        let mix = { (lhs: Double, rhs: Double) in
+            Int((lhs + (rhs - lhs) * amount) * 255.0)
+        }
+
+        return String(format: "#%02X%02X%02X", mix(base.r, target.r), mix(base.g, target.g), mix(base.b, target.b))
+    }
+}

--- a/readeck/UI/readeckApp.swift
+++ b/readeck/UI/readeckApp.swift
@@ -30,6 +30,7 @@ struct readeckApp: App {
             .environment(deepLinkRouter)
             .environment(\.managedObjectContext, CoreDataManager.shared.context)
             .preferredColorScheme(appSettings.theme.colorScheme)
+            .oledTheme(appSettings.theme.isOLED)
             .onOpenURL { url in
                 deepLinkRouter.handle(url: url)
             }


### PR DESCRIPTION
Adds OLED as a fourth app theme: renders as dark mode but forces true black chrome instead of the elevated system gray.

Second commit generalizes the same fix: reader color themes now color the entire reader view (nav bar, safe areas, surrounding space), not just the article HTML. The effective colors are resolved once and shared by the SwiftUI chrome and the injected CSS, replacing a switch that was duplicated across four files. Whether a theme needs light foreground is derived from the background's brightness, so custom colors work too.

Closes #113