### PR TITLE
feat(reader): add an archive action to the reader menu

### DIFF
--- a/readeck/Localizations/Base.lproj/Localizable.strings
+++ b/readeck/Localizations/Base.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "This is how your bookmark descriptions and article text will appear in the app. The quick brown fox jumps over the lazy dog." = "This is how your bookmark descriptions and article text will appear in the app. The quick brown fox jumps over the lazy dog.";
 "Try Again" = "Try Again";
 "Unable to load bookmarks" = "Unable to load bookmarks";
+"Unarchive" = "Unarchive";
 "Unarchive Bookmark" = "Unarchive Bookmark";
 "URL in clipboard:" = "URL in clipboard:";
 "Username" = "Username";
@@ -186,3 +187,5 @@
 "No article content to summarize." = "No article content to summarize.";
 "Delete this bookmark?" = "Delete this bookmark?";
 "This action cannot be undone." = "This action cannot be undone.";
+"Archive this bookmark?" = "Archive this bookmark?";
+"Unarchive this bookmark?" = "Unarchive this bookmark?";

--- a/readeck/Localizations/de.lproj/Localizable.strings
+++ b/readeck/Localizations/de.lproj/Localizable.strings
@@ -159,6 +159,7 @@
 "This is how your bookmark descriptions and article text will appear in the app. The quick brown fox jumps over the lazy dog." = "So werden Lesezeichen-Beschreibungen und Artikeltexte in der App angezeigt. Franz jagt im komplett verwahrlosten Taxi quer durch Bayern.";
 "Try Again" = "Erneut versuchen";
 "Unable to load bookmarks" = "Lesezeichen können nicht geladen werden";
+"Unarchive" = "Aus Archiv entfernen";
 "Unarchive Bookmark" = "Lesezeichen aus Archiv entfernen";
 "URL in clipboard:" = "URL in Zwischenablage:";
 "Username" = "Benutzername";
@@ -280,6 +281,8 @@
 "No article content to summarize." = "Kein Artikelinhalt zum Zusammenfassen vorhanden.";
 "Delete this bookmark?" = "Dieses Lesezeichen löschen?";
 "This action cannot be undone." = "Diese Aktion kann nicht rückgängig gemacht werden.";
+"Archive this bookmark?" = "Dieses Lesezeichen archivieren?";
+"Unarchive this bookmark?" = "Dieses Lesezeichen aus dem Archiv entfernen?";
 
 /* Unread Badge */
 "Show Unread Count on App Icon" = "Ungelesen-Anzahl auf App-Icon anzeigen";

--- a/readeck/Localizations/en.lproj/Localizable.strings
+++ b/readeck/Localizations/en.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "This is how your bookmark descriptions and article text will appear in the app. The quick brown fox jumps over the lazy dog." = "This is how your bookmark descriptions and article text will appear in the app. The quick brown fox jumps over the lazy dog.";
 "Try Again" = "Try Again";
 "Unable to load bookmarks" = "Unable to load bookmarks";
+"Unarchive" = "Unarchive";
 "Unarchive Bookmark" = "Unarchive Bookmark";
 "URL in clipboard:" = "URL in clipboard:";
 "Username" = "Username";
@@ -272,6 +273,8 @@
 "No article content to summarize." = "No article content to summarize.";
 "Delete this bookmark?" = "Delete this bookmark?";
 "This action cannot be undone." = "This action cannot be undone.";
+"Archive this bookmark?" = "Archive this bookmark?";
+"Unarchive this bookmark?" = "Unarchive this bookmark?";
 
 /* Unread Badge */
 "Show Unread Count on App Icon" = "Show Unread Count on App Icon";

--- a/readeck/UI/BookmarkDetail/ArticleReaderView.swift
+++ b/readeck/UI/BookmarkDetail/ArticleReaderView.swift
@@ -19,6 +19,7 @@ struct ArticleReaderView: View {
     @State private var showingImageViewer = false
     @State private var showingErrorAlert = false
     @State private var showingDeleteConfirmation = false
+    @State private var showingArchiveConfirmation = false
     @State private var isToolbarVisible: Bool = true
     @State private var scrollTracker = ScrollTracker()
 
@@ -81,6 +82,19 @@ struct ArticleReaderView: View {
                 }
             } message: {
                 Text("This action cannot be undone.".localized)
+            }
+            .alert(
+                viewModel.bookmarkDetail.isArchived ? "Unarchive this bookmark?".localized : "Archive this bookmark?".localized,
+                isPresented: $showingArchiveConfirmation
+            ) {
+                Button("Cancel".localized, role: .cancel) {}
+                // Capture the target state up front so it cannot flip while the request runs.
+                let shouldArchive = !viewModel.bookmarkDetail.isArchived
+                Button(shouldArchive ? "Archive".localized : "Unarchive".localized) {
+                    Task {
+                        await viewModel.archiveBookmark(id: bookmarkId, isArchive: shouldArchive)
+                    }
+                }
             }
             .onChange(of: showingFontSettings) { _, isShowing in
                 if !isShowing {
@@ -262,6 +276,17 @@ struct ArticleReaderView: View {
                 } label: {
                     Label("Font Settings".localized, systemImage: "textformat")
                 }
+
+                Button {
+                    showingArchiveConfirmation = true
+                } label: {
+                    if viewModel.bookmarkDetail.isArchived {
+                        Label("Unarchive".localized, systemImage: "tray.and.arrow.up")
+                    } else {
+                        Label("Archive".localized, systemImage: "archivebox")
+                    }
+                }
+                .disabled(!appSettings.isNetworkConnected || viewModel.isLoading)
 
                 Divider()
 


### PR DESCRIPTION
Archive was only reachable through the floating button. Adds it to the 3-dot menu, above the divider that separates the destructive delete, with a confirmation.

Behaves exactly like the floating button, so the After Archiving preference keeps driving navigation. Icons match the existing swipe actions. Localized in Base, en and de.

Closes #114